### PR TITLE
Universal bridge contracts

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,15 @@
+{
+  "overrides": [
+    {
+      "files": "*.sol",
+      "options": {
+        "printWidth": 120,
+        "tabWidth": 4,
+        "useTabs": false,
+        "singleQuote": false,
+        "bracketSpacing": true,
+        "explicitTypes": "always"
+      }
+    }
+  ]
+}

--- a/contracts/MultiTokenBridge.sol
+++ b/contracts/MultiTokenBridge.sol
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+import { IERC20Bridgeable } from "./interfaces/IERC20Bridgeable.sol";
+import { IMultiTokenBridge } from "./interfaces/IMultiTokenBridge.sol";
+import { MultiTokenBridgeStorage } from "./MultiTokenBridgeStorage.sol";
+import { PauseControlUpgradeable } from "./base/PauseControlUpgradeable.sol";
+import { RescueControlUpgradeable } from "./base/RescueControlUpgradeable.sol";
+import { StoragePlaceholder200 } from "./base/StoragePlaceholder.sol";
+
+/**
+ * @title MultiTokenBridgeUpgradeable contract
+ * @dev Allows to bridge coins of multiple token contracts between blockchains.
+ * See terms in the comments of the {IMultiTokenBridge} interface.
+ */
+contract MultiTokenBridge is
+    AccessControlUpgradeable,
+    PauseControlUpgradeable,
+    RescueControlUpgradeable,
+    StoragePlaceholder200,
+    MultiTokenBridgeStorage,
+    IMultiTokenBridge
+{
+    /// @dev The contract owner role.
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @dev The role who is allowed to execute bridge operations.
+    bytes32 public constant BRIDGER_ROLE = keccak256("BRIDGER_ROLE");
+
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    // -------------------- Events -----------------------------------
+
+    /// @dev Emitted when the mode of relocation with specified parameters is changed.
+    event SetRelocationMode(
+        uint256 indexed chainId, // The destination chain ID of the relocation.
+        address indexed token,   // The address of the token contract whose coins are being relocated.
+        OperationMode oldMode,   // The old mode of the relocation.
+        OperationMode newMode    // The new mode of the relocation.
+    );
+
+    /// @dev Emitted when mode of accommodation with specified parameters is changed.
+    event SetAccommodationMode(
+        uint256 indexed chainId, // The source chain ID of the accommodation.
+        address indexed token,   // The address of the token contract whose coins are being accommodated.
+        OperationMode oldMode,   // The old mode of the accommodation.
+        OperationMode newMode    // The new mode of the accommodation.
+    );
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The zero address of a token contract has been passed when request a relocation.
+    error ZeroRelocationTokenAddress();
+
+    /// @dev The zero amount of tokens has been passed when request a relocation.
+    error ZeroRelocationAmount();
+
+    /// @dev Relocation to the provided chain for the provided token is not supported by this bridge.
+    error UnsupportedRelocation();
+
+    /// @dev The underlying token contract does not support this bridge to execute needed operations.
+    error UnsupportingToken();
+
+    /// @dev The transaction sender is not authorized to execute the requested function with provided arguments.
+    error UnauthorizedTransactionSender();
+
+    /// @dev The provided array of relocation nonces as a function argument is empty.
+    error EmptyNonceArray();
+
+    /// @dev The zero relocation count has been passed as a function argument.
+    error ZeroRelocationCount();
+
+    /// @dev The requested count of relocations to process is greater than the current number of pending relocations.
+    error LackOfPendingRelocations();
+
+    /// @dev A token burning failure happened during a bridge operation.
+    error TokenBurningFailure();
+
+    /// @dev The zero nonce has been passed to accommodate tokens.
+    error ZeroAccommodationNonce();
+
+    /// @dev A nonce mismatch has been found during token accommodation.
+    error AccommodationNonceMismatch();
+
+    /// @dev The provided array of relocations as a function argument is empty.
+    error EmptyRelocationArray();
+
+    /// @dev Accommodation from the provided chain for the provided token contract is not supported by this bridge.
+    error UnsupportedAccommodation();
+
+    /// @dev The zero account address has been passed to accommodate tokens.
+    error ZeroAccommodationAccount();
+
+    /// @dev The zero amount of tokens has been passed to accommodate tokens.
+    error ZeroAccommodationAmount();
+
+    /// @dev A token minting failure happened during a bridge operation.
+    error TokenMintingFailure();
+
+    /// @dev The provided token contract does not support the bridge operations.
+    error NonBridgeableToken();
+
+    /// @dev The relocation with the provided nonce is already processed so it cannot be canceled.
+    error AlreadyProcessedRelocation();
+
+    /// @dev The relocation with the provided nonce does not exist so it cannot be canceled.
+    error NotExistentRelocation();
+
+    /// @dev The relocation with the provided nonce is already canceled.
+    error AlreadyCanceledRelocation();
+
+    // -------------------- Functions -----------------------------------
+
+    function initialize() public initializer {
+        __MultiTokenBridge_init();
+    }
+
+    function __MultiTokenBridge_init() internal onlyInitializing {
+        __AccessControl_init_unchained();
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __Pausable_init_unchained();
+        __PauseControl_init_unchained(OWNER_ROLE);
+        __RescueControl_init_unchained(OWNER_ROLE);
+
+        __MultiTokenBridge_init_unchained();
+    }
+
+    function __MultiTokenBridge_init_unchained() internal onlyInitializing {
+        _setRoleAdmin(OWNER_ROLE, OWNER_ROLE);
+        _setRoleAdmin(BRIDGER_ROLE, OWNER_ROLE);
+
+        _setupRole(OWNER_ROLE, _msgSender());
+    }
+
+    /// @dev See {IMultiTokenBridge-getPendingRelocationCounter}.
+    function getPendingRelocationCounter(uint256 chainId) external view returns (uint256) {
+        return _pendingRelocationCounters[chainId];
+    }
+
+    /// @dev See {IMultiTokenBridge-getLastProcessedRelocationNonce}.
+    function getLastProcessedRelocationNonce(uint256 chainId) external view returns (uint256) {
+        return _lastProcessedRelocationNonces[chainId];
+    }
+
+    /// @dev See {IMultiTokenBridge-getRelocationMode}.
+    function getRelocationMode(uint256 chainId, address token) external view returns (OperationMode) {
+        return _relocationModes[chainId][token];
+    }
+
+    /// @dev See {IMultiTokenBridge-getRelocation}.
+    function getRelocation(uint256 chainId, uint256 nonce) external view returns (Relocation memory) {
+        return _relocations[chainId][nonce];
+    }
+
+    /// @dev See {IMultiTokenBridge-getAccommodationMode}.
+    function getAccommodationMode(uint256 chainId, address token) external view returns (OperationMode) {
+        return _accommodationModes[chainId][token];
+    }
+
+    /// @dev See {IMultiTokenBridge-getLastAccommodationNonce}.
+    function getLastAccommodationNonce(uint256 chainId) external view returns (uint256) {
+        return _lastAccommodationNonces[chainId];
+    }
+
+    /// @dev See {IMultiTokenBridge-getRelocations}.
+    function getRelocations(
+        uint256 chainId,
+        uint256 nonce,
+        uint256 count
+    ) external view returns (Relocation[] memory relocations) {
+        relocations = new Relocation[](count);
+        for (uint256 i = 0; i < count; i++) {
+            relocations[i] = _relocations[chainId][nonce];
+            nonce += 1;
+        }
+    }
+
+    /**
+     * @dev See {IMultiTokenBridge-requestRelocation}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The provided address of the token contract whose coins are being relocated must not be zero.
+     * - The provided amount of tokens to relocate must not be zero.
+     * - The relocation to the destination chain for the provided token contract must be supported.
+     * - If the mode of the relocation is BurnOrMint
+     *   the provided token contract must support this bridge to execute needed operation.
+     * - The caller must have the provided amount of tokens.
+     */
+    function requestRelocation(
+        uint256 chainId,
+        address token,
+        uint256 amount
+    ) external whenNotPaused returns (uint256 nonce) {
+        if (token == address(0)) {
+            revert ZeroRelocationTokenAddress();
+        }
+        if (amount == 0) {
+            revert ZeroRelocationAmount();
+        }
+        OperationMode mode = _relocationModes[chainId][token];
+        if (mode == OperationMode.Unsupported) {
+            revert UnsupportedRelocation();
+        }
+        if (mode == OperationMode.BurnOrMint) {
+            if (!IERC20Bridgeable(token).isBridgeSupported(address(this))) {
+                revert UnsupportingToken();
+            }
+        }
+
+        uint256 newPendingRelocationCount = _pendingRelocationCounters[chainId] + 1;
+        nonce = _lastProcessedRelocationNonces[chainId] + newPendingRelocationCount;
+        _pendingRelocationCounters[chainId] = newPendingRelocationCount;
+        Relocation storage relocation = _relocations[chainId][nonce];
+        relocation.account = _msgSender();
+        relocation.token = token;
+        relocation.amount = amount;
+
+        IERC20Upgradeable(token).safeTransferFrom(
+            _msgSender(),
+            address(this),
+            amount
+        );
+
+        emit RequestRelocation(
+            chainId,
+            token,
+            _msgSender(),
+            amount,
+            nonce
+        );
+    }
+
+    /**
+     * @dev See {IMultiTokenBridge-cancelRelocation}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must be the initiator of the relocation that is being canceled.
+     * - The relocation for the provided chain ID and nonce must not be already processed.
+     * - The relocation for the provided chain ID and nonce must exist.
+     * - The relocation for the provided chain ID and nonce must not be already canceled.
+     */
+    function cancelRelocation(uint256 chainId, uint256 nonce) external whenNotPaused {
+        if (_relocations[chainId][nonce].account != _msgSender()) {
+            revert UnauthorizedTransactionSender();
+        }
+
+        cancelRelocationInternal(chainId, nonce);
+    }
+
+    /**
+     * @dev See {IMultiTokenBridge-cancelRelocations}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {BRIDGER_ROLE} role.
+     * - The provided array of relocation nonces must not be empty.
+     * - All the relocation for the provided chain ID and nonces must not be already processed.
+     * - All the relocation for the provided chain ID and nonces must exist.
+     * - All the relocation for the provided chain ID and nonces must not be already canceled.
+     */
+    function cancelRelocations(uint256 chainId, uint256[] memory nonces) external whenNotPaused onlyRole(BRIDGER_ROLE) {
+        if (nonces.length == 0) {
+            revert EmptyNonceArray();
+        }
+
+        for (uint256 i = 0; i < nonces.length; i++) {
+            cancelRelocationInternal(chainId, nonces[i]);
+        }
+    }
+
+    /**
+     * @dev See {IMultiTokenBridge-relocate}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {BRIDGER_ROLE} role.
+     * - The provided count of relocations to process must not be zero.
+     * - The provided count of relocations to process must not be greater than the number of pending relocations.
+     * - For all the relocations that are executed is BurnOrMint operation mode
+     *   the related token contracts whose coins are being relocated must support this bridge
+     *   and must execute burning operations successfully.
+     */
+    function relocate(uint256 chainId, uint256 count) external whenNotPaused onlyRole(BRIDGER_ROLE) {
+        if (count == 0) {
+            revert ZeroRelocationCount();
+        }
+        uint256 currentPendingRelocationCount = _pendingRelocationCounters[chainId];
+        if (count > currentPendingRelocationCount) {
+            revert LackOfPendingRelocations();
+        }
+
+        uint256 fromNonce = _lastProcessedRelocationNonces[chainId] + 1;
+        uint256 toNonce = fromNonce + count - 1;
+
+        _pendingRelocationCounters[chainId] = currentPendingRelocationCount - count;
+        _lastProcessedRelocationNonces[chainId] = toNonce;
+
+        for (uint256 nonce = fromNonce; nonce <= toNonce; nonce++) {
+            Relocation memory relocation = _relocations[chainId][nonce];
+            if (!relocation.canceled) {
+                OperationMode mode = _relocationModes[chainId][relocation.token];
+                relocateInternal(relocation, mode);
+                emit Relocate(
+                    chainId,
+                    relocation.token,
+                    relocation.account,
+                    relocation.amount,
+                    nonce,
+                    mode
+                );
+            }
+        }
+    }
+
+    /**
+     * @dev See {IMultiTokenBridge-accommodate}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {BRIDGER_ROLE} role.
+     * - The provided nonce of the first relocation must not be zero.
+     * - The provided nonce of the first relocation must be one more than the nonce of the last accommodation.
+     * - The provided array of relocations must not be empty.
+     * - This bridge must support accommodations from the chain with the provided ID and
+     *   for all token contracts of the provided array of relocations.
+     * - All the provided relocations must have non-zero account address.
+     * - All the provided relocations must have non-zero token amount.
+     * - For all the accommodations whose mode is BurnAndMint
+     *   the related token contracts whose coins are being accommodated must support this bridge
+     *   and must execute minting operations successfully.
+     */
+    function accommodate(
+        uint256 chainId,
+        uint256 nonce,
+        Relocation[] memory relocations
+    ) external whenNotPaused onlyRole(BRIDGER_ROLE) {
+        if (nonce == 0) {
+            revert ZeroAccommodationNonce();
+        }
+        if (_lastAccommodationNonces[chainId] != (nonce - 1)) {
+            revert AccommodationNonceMismatch();
+        }
+        if (relocations.length == 0) {
+            revert EmptyRelocationArray();
+        }
+
+        for (uint256 i = 0; i < relocations.length; i++) {
+            Relocation memory relocation = relocations[i];
+            if (_accommodationModes[chainId][relocation.token] == OperationMode.Unsupported) {
+                revert UnsupportedAccommodation();
+            }
+            if (relocation.account == address(0)) {
+                revert ZeroAccommodationAccount();
+            }
+            if (relocation.amount == 0) {
+                revert ZeroAccommodationAmount();
+            }
+            if (!relocation.canceled) {
+                OperationMode mode = _accommodationModes[chainId][relocation.token];
+                accommodateInternal(relocation, mode);
+                emit Accommodate(
+                    chainId,
+                    relocation.token,
+                    relocation.account,
+                    relocation.amount,
+                    nonce,
+                    mode
+                );
+            }
+            nonce += 1;
+        }
+
+        _lastAccommodationNonces[chainId] = nonce - 1;
+    }
+
+    /**
+     * @dev Sets the mode of relocation to a destination chain for a local token contract.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {OWNER_ROLE} role.
+     * - The new relocation mode must defer from the current one.
+     * - If the new relocation mode is BurnOrMint the underlying token contract must support the bridge operations.
+     *
+     * Emits a {SetRelocationMode} event.
+     *
+     * @param chainId The ID of the destination chain to relocate to.
+     * @param token The address of the local token contract whose coins are being relocated.
+     * @param newMode The new relocation mode.
+     */
+    function setRelocationMode(
+        uint256 chainId,
+        address token,
+        OperationMode newMode
+    ) external onlyRole(OWNER_ROLE) {
+        OperationMode oldMode = _relocationModes[chainId][token];
+        if (oldMode == newMode) {
+            return;
+        }
+        if (newMode == OperationMode.BurnOrMint) {
+            if (!isTokenIERC20BridgeableInternal(token)) {
+                revert NonBridgeableToken();
+            }
+        }
+        _relocationModes[chainId][token] = newMode;
+        emit SetRelocationMode(chainId, token, oldMode, newMode);
+    }
+
+    /**
+     * @dev Sets the mode of accommodation from a source chain for a local token contract.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {OWNER_ROLE} role.
+     * - The new accommodation mode must defer from the current one.
+     * - If the new accommodation mode is BurnOrMint the underlying token contract must support the bridge operations.
+     *
+     * Emits a {SetAccommodationMode} event.
+     *
+     * @param chainId The ID of the source chain to accommodate from.
+     * @param token The address of the local token contract whose coins are being accommodated.
+     * @param newMode The new accommodation mode.
+     */
+    function setAccommodationMode(
+        uint256 chainId,
+        address token,
+        OperationMode newMode
+    ) external onlyRole(OWNER_ROLE) {
+        OperationMode oldMode = _accommodationModes[chainId][token];
+        if (oldMode == newMode) {
+            return;
+        }
+        if (newMode == OperationMode.BurnOrMint) {
+            if (!isTokenIERC20BridgeableInternal(token)) {
+                revert NonBridgeableToken();
+            }
+        }
+        _accommodationModes[chainId][token] = newMode;
+        emit SetAccommodationMode(chainId, token, oldMode, newMode);
+    }
+
+    function cancelRelocationInternal(uint256 chainId, uint256 nonce) internal {
+        uint256 lastProcessedRelocationNonce = _lastProcessedRelocationNonces[chainId];
+        if (nonce <= lastProcessedRelocationNonce) {
+            revert AlreadyProcessedRelocation();
+        }
+        if (nonce > lastProcessedRelocationNonce + _pendingRelocationCounters[chainId]) {
+            revert NotExistentRelocation();
+        }
+
+        Relocation storage relocation = _relocations[chainId][nonce];
+
+        if (relocation.canceled) {
+            revert AlreadyCanceledRelocation();
+        }
+
+        relocation.canceled = true;
+        IERC20Upgradeable(relocation.token).safeTransfer(relocation.account, relocation.amount);
+
+        emit CancelRelocation(
+            chainId,
+            relocation.token,
+            relocation.account,
+            relocation.amount,
+            nonce
+        );
+    }
+
+    function relocateInternal(Relocation memory relocation, OperationMode mode) internal {
+        if (mode == OperationMode.BurnOrMint) {
+            if (!IERC20Bridgeable(relocation.token).isBridgeSupported(address(this))) {
+                revert UnsupportingToken();
+            }
+            bool burningSuccess = IERC20Bridgeable(relocation.token).burnForBridging(
+                relocation.account,
+                relocation.amount
+            );
+            if (!burningSuccess) {
+                revert TokenBurningFailure();
+            }
+        } else {
+            // Do nothing, tokens are locked on the bridge account
+        }
+    }
+
+    function accommodateInternal(Relocation memory relocation, OperationMode mode) internal {
+        if (mode == OperationMode.BurnOrMint) {
+            if (!IERC20Bridgeable(relocation.token).isBridgeSupported(address(this))) {
+                revert UnsupportingToken();
+            }
+            bool mintingSuccess = IERC20Bridgeable(relocation.token).mintForBridging(
+                relocation.account,
+                relocation.amount
+            );
+            if (!mintingSuccess) {
+                revert TokenMintingFailure();
+            }
+        } else {
+            IERC20Upgradeable(relocation.token).safeTransfer(relocation.account, relocation.amount);
+        }
+    }
+
+    // Safely call the appropriate function from the IERC20Bridgeable interface.
+    function isTokenIERC20BridgeableInternal(address token) internal virtual returns (bool) {
+        (bool success, bytes memory result) = token.staticcall(abi.encodeWithSignature("isIERC20Bridgeable()"));
+        if (success && result.length > 0) {
+            return abi.decode(result, (bool));
+        } else {
+            return false;
+        }
+    }
+}

--- a/contracts/MultiTokenBridgeStorage.sol
+++ b/contracts/MultiTokenBridgeStorage.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { IMultiTokenBridgeTypes } from "./interfaces/IMultiTokenBridge.sol";
+
+/**
+ * @title MultiTokenBridge storage version 1
+ * @dev See terms in the comments of the {IMultiTokenBridge} interface.
+ */
+abstract contract MultiTokenBridgeStorageV1 is IMultiTokenBridgeTypes {
+    /// @dev The mapping: a destination chain ID => the number of pending relocations to that chain.
+    mapping(uint256 => uint256) internal _pendingRelocationCounters;
+
+    /// @dev The mapping: a destination chain ID => the nonce of the last processed relocation to that chain.
+    mapping(uint256 => uint256) internal _lastProcessedRelocationNonces;
+
+    /**
+     * @dev The mapping: a destination chain ID, a token contract address => the mode of relocation
+     * to that chain for that token
+     */
+    mapping(uint256 => mapping(address => OperationMode)) internal _relocationModes;
+
+    /// @dev The mapping: a destination chain ID, a nonce => the relocation structure matching to that chain and nonce.
+    mapping(uint256 => mapping(uint256 => Relocation)) internal _relocations;
+
+    /**
+     * @dev The mapping: a source chain ID, a token contract address => the mode of accommodation
+     * from that chain for that token
+     */
+    mapping(uint256 => mapping(address => OperationMode)) internal _accommodationModes;
+
+    /// @dev The mapping: a source chain ID => the nonce of the last accommodation from that chain.
+    mapping(uint256 => uint256) internal _lastAccommodationNonces;
+}
+
+/**
+ * @title MultiTokenBridge storage
+ * @dev Contains storage variables of the multi token bridge contract.
+ *
+ * We are following Compound's approach of upgrading new contract implementations.
+ * See https://github.com/compound-finance/compound-protocol.
+ * When we need to add new storage variables, we create a new version of MultiTokenBridgeStorage
+ * e.g. MultiTokenBridgeStorage<versionNumber>, so finally it would look like
+ * "contract MultiTokenBridgeStorage is MultiTokenBridgeStorageV1, MultiTokenBridgeStorageV2".
+ */
+abstract contract MultiTokenBridgeStorage is MultiTokenBridgeStorageV1 {
+
+}

--- a/contracts/TokenBridge.sol
+++ b/contracts/TokenBridge.sol
@@ -1,0 +1,511 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+import { IERC20Bridgeable } from "./interfaces/IERC20Bridgeable.sol";
+import { ITokenBridge } from "./interfaces/ITokenBridge.sol";
+import { TokenBridgeStorage } from "./TokenBridgeStorage.sol";
+import { PauseControlUpgradeable } from "./base/PauseControlUpgradeable.sol";
+import { RescueControlUpgradeable } from "./base/RescueControlUpgradeable.sol";
+import { StoragePlaceholder200 } from "./base/StoragePlaceholder.sol";
+
+/**
+ * @title TokenBridgeUpgradeable contract
+ * @dev Allows to bridge coins of a single token contract between blockchains.
+ * See terms in the comments of the {ITokenBridge} interface.
+ */
+contract TokenBridge is
+    AccessControlUpgradeable,
+    PauseControlUpgradeable,
+    RescueControlUpgradeable,
+    StoragePlaceholder200,
+    TokenBridgeStorage,
+    ITokenBridge
+{
+    /// @dev The contract owner role.
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @dev The role who is allowed to execute bridge operations.
+    bytes32 public constant BRIDGER_ROLE = keccak256("BRIDGER_ROLE");
+
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    // -------------------- Events -----------------------------------
+
+    /// @dev Emitted when the mode of relocation to a specified chain is changed.
+    event SetRelocationMode(
+        uint256 indexed chainId, // The destination chain ID of the relocation.
+        OperationMode oldMode,   // The old mode of the relocation.
+        OperationMode newMode    // The new mode of the relocation.
+    );
+
+    /// @dev Emitted when mode of accommodation from a specified chain is changed.
+    event SetAccommodationMode(
+        uint256 indexed chainId, // The source chain ID of the accommodation.
+        OperationMode oldMode,   // The old mode of the accommodation.
+        OperationMode newMode    // The new mode of the accommodation.
+    );
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The zero amount of tokens has been passed when request a relocation.
+    error ZeroRelocationAmount();
+
+    /// @dev Relocation to the provided chain is not supported by this bridge.
+    error UnsupportedRelocation();
+
+    /// @dev The underlying token contract does not support this bridge to execute needed operations.
+    error UnsupportingToken();
+
+    /// @dev The transaction sender is not authorized to execute the requested function with provided arguments.
+    error UnauthorizedTransactionSender();
+
+    /// @dev The provided array of relocation nonces as a function argument is empty.
+    error EmptyNonceArray();
+
+    /// @dev The zero relocation count has been passed as a function argument.
+    error ZeroRelocationCount();
+
+    /// @dev The requested count of relocations to process is greater than the current number of pending relocations.
+    error LackOfPendingRelocations();
+
+    /// @dev A token burning failure happened during a bridge operation.
+    error TokenBurningFailure();
+
+    /// @dev Accommodation from the provided chain for the underlying token contract is not supported by this bridge.
+    error UnsupportedAccommodation();
+
+    /// @dev The zero nonce has been passed to accommodate tokens.
+    error ZeroAccommodationNonce();
+
+    /// @dev A nonce mismatch has been found during token accommodation.
+    error AccommodationNonceMismatch();
+
+    /// @dev The provided array of relocations as a function argument is empty.
+    error EmptyRelocationArray();
+
+    /// @dev The zero account address has been passed to accommodate tokens.
+    error ZeroAccommodationAccount();
+
+    /// @dev The zero amount of tokens has been passed to accommodate tokens.
+    error ZeroAccommodationAmount();
+
+    /// @dev A token minting failure happened during a bridge operation.
+    error TokenMintingFailure();
+
+    /// @dev The underlying token contract does not support the bridge operations.
+    error NonBridgeableToken();
+
+    /// @dev The mode of the relocation to the provided chain has not been changed during the function call.
+    error UnchangedRelocationMode();
+
+    /// @dev The mode of the accommodation from the provided chain has not been changed during the function call.
+    error UnchangedAccommodationMode();
+
+    /// @dev The relocation with the provided nonce is already processed so it cannot be canceled.
+    error AlreadyProcessedRelocation();
+
+    /// @dev The relocation with the provided nonce does not exist so it cannot be canceled.
+    error NotExistentRelocation();
+
+    /// @dev The relocation with the provided nonce is already canceled.
+    error AlreadyCanceledRelocation();
+
+    // ------------------- Functions ---------------------------------
+
+    function initialize(address token_) public initializer {
+        __TokenBridge_init(token_);
+    }
+
+    function __TokenBridge_init(address token_) internal onlyInitializing {
+        __AccessControl_init_unchained();
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __Pausable_init_unchained();
+        __PauseControl_init_unchained(OWNER_ROLE);
+        __RescueControl_init_unchained(OWNER_ROLE);
+
+        __TokenBridge_init_unchained(token_);
+    }
+
+    function __TokenBridge_init_unchained(address token_) internal onlyInitializing {
+        _token = token_;
+
+        _setRoleAdmin(OWNER_ROLE, OWNER_ROLE);
+        _setRoleAdmin(BRIDGER_ROLE, OWNER_ROLE);
+
+        _setupRole(OWNER_ROLE, _msgSender());
+    }
+
+    /// @dev See {ITokenBridge-underlyingToken}.
+    function underlyingToken() external view returns (address) {
+        return _token;
+    }
+
+    /// @dev See {ITokenBridge-getPendingRelocationCounter}.
+    function getPendingRelocationCounter(uint256 chainId) external view returns (uint256) {
+        return _pendingRelocationCounters[chainId];
+    }
+
+    /// @dev See {ITokenBridge-getLastProcessedRelocationNonce}.
+    function getLastProcessedRelocationNonce(uint256 chainId) external view returns (uint256) {
+        return _lastProcessedRelocationNonces[chainId];
+    }
+
+    /// @dev See {ITokenBridge-getRelocationMode}.
+    function getRelocationMode(uint256 chainId) external view returns (OperationMode) {
+        return _relocationModes[chainId];
+    }
+
+    /// @dev See {ITokenBridge-getRelocation}.
+    function getRelocation(uint256 chainId, uint256 nonce) external view returns (Relocation memory) {
+        return _relocations[chainId][nonce];
+    }
+
+    /// @dev See {ITokenBridge-getAccommodationMode}.
+    function getAccommodationMode(uint256 chainId) external view returns (OperationMode) {
+        return _accommodationModes[chainId];
+    }
+
+    /// @dev See {ITokenBridge-getLastAccommodationNonce}.
+    function getLastAccommodationNonce(uint256 chainId) external view returns (uint256) {
+        return _lastAccommodationNonces[chainId];
+    }
+
+    /// @dev See {ITokenBridge-getRelocations}.
+    function getRelocations(
+        uint256 chainId,
+        uint256 nonce,
+        uint256 count
+    ) external view returns (Relocation[] memory relocations) {
+        relocations = new Relocation[](count);
+        for (uint256 i = 0; i < count; i++) {
+            relocations[i] = _relocations[chainId][nonce];
+            nonce += 1;
+        }
+    }
+
+    /**
+     * @dev See {ITokenBridge-requestRelocation}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The provided amount of tokens to relocate must not be zero.
+     * - The relocation to the destination chain must be supported.
+     * - If the mode of the relocation is BurnOrMint
+     *   the underlying token contract must support this bridge to execute needed operation.
+     * - The caller must have the provided amount of tokens.
+     */
+    function requestRelocation(uint256 chainId, uint256 amount) external whenNotPaused returns (uint256 nonce) {
+        if (amount == 0) {
+            revert ZeroRelocationAmount();
+        }
+        OperationMode mode = _relocationModes[chainId];
+        if (mode == OperationMode.Unsupported) {
+            revert UnsupportedRelocation();
+        }
+        if (mode == OperationMode.BurnOrMint) {
+            if (!IERC20Bridgeable(_token).isBridgeSupported(address(this))) {
+                revert UnsupportingToken();
+            }
+        }
+
+        uint256 newPendingRelocationCount = _pendingRelocationCounters[chainId] + 1;
+        nonce = _lastProcessedRelocationNonces[chainId] + newPendingRelocationCount;
+        _pendingRelocationCounters[chainId] = newPendingRelocationCount;
+        Relocation storage relocation = _relocations[chainId][nonce];
+        relocation.account = _msgSender();
+        relocation.amount = amount;
+
+        IERC20Upgradeable(_token).safeTransferFrom(
+            _msgSender(),
+            address(this),
+            amount
+        );
+
+        emit RequestRelocation(
+            chainId,
+            _msgSender(),
+            amount,
+            nonce
+        );
+    }
+
+    /**
+     * @dev See {ITokenBridge-cancelRelocation}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must be the initiator of the relocation that is being canceled.
+     * - The relocation for the provided chain ID and nonce must not be already processed.
+     * - The relocation for the provided chain ID and nonce must exist.
+     * - The relocation for the provided chain ID and nonce must not be already canceled.
+     */
+    function cancelRelocation(uint256 chainId, uint256 nonce) external whenNotPaused {
+        if (_relocations[chainId][nonce].account != _msgSender()) {
+            revert UnauthorizedTransactionSender();
+        }
+
+        cancelRelocationInternal(chainId, nonce);
+    }
+
+    /**
+     * @dev See {ITokenBridge-cancelRelocations}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {BRIDGER_ROLE} role.
+     * - The provided array of relocation nonces must not be empty.
+     * - All the relocation for the provided chain ID and nonces must not be already processed.
+     * - All the relocation for the provided chain ID and nonces must exist.
+     * - All the relocation for the provided chain ID and nonces must not be already canceled.
+     */
+    function cancelRelocations(uint256 chainId, uint256[] memory nonces) external whenNotPaused onlyRole(BRIDGER_ROLE) {
+        if (nonces.length == 0) {
+            revert EmptyNonceArray();
+        }
+
+        for (uint256 i = 0; i < nonces.length; i++) {
+            cancelRelocationInternal(chainId, nonces[i]);
+        }
+    }
+
+    /**
+     * @dev See {ITokenBridge-relocate}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {BRIDGER_ROLE} role.
+     * - The provided count of relocations to process must not be zero.
+     * - The provided count of relocations to process must not be greater than the number of pending relocations.
+     * - For all the relocations that are executed is BurnOrMint operation mode
+     *   the underlying token contract must support this bridge and must execute burning operations successfully.
+     */
+    function relocate(uint256 chainId, uint256 count) external whenNotPaused onlyRole(BRIDGER_ROLE) {
+        if (count == 0) {
+            revert ZeroRelocationCount();
+        }
+        uint256 currentPendingRelocationCount = _pendingRelocationCounters[chainId];
+        if (count > currentPendingRelocationCount) {
+            revert LackOfPendingRelocations();
+        }
+        OperationMode mode = _relocationModes[chainId];
+        if (mode == OperationMode.BurnOrMint) {
+            if (!IERC20Bridgeable(_token).isBridgeSupported(address(this))) {
+                revert UnsupportingToken();
+            }
+        }
+
+        uint256 fromNonce = _lastProcessedRelocationNonces[chainId] + 1;
+        uint256 toNonce = fromNonce + count - 1;
+
+        _pendingRelocationCounters[chainId] = currentPendingRelocationCount - count;
+        _lastProcessedRelocationNonces[chainId] = toNonce;
+
+        for (uint256 nonce = fromNonce; nonce <= toNonce; nonce++) {
+            Relocation memory relocation = _relocations[chainId][nonce];
+            if (!relocation.canceled) {
+                relocateInternal(relocation, mode);
+                emit Relocate(
+                    chainId,
+                    relocation.account,
+                    relocation.amount,
+                    nonce,
+                    mode
+                );
+            }
+        }
+    }
+
+    /**
+     * @dev See {ITokenBridge-accommodate}.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {BRIDGER_ROLE} role.
+     * - The provided nonce of the first relocation must not be zero.
+     * - The provided nonce of the first relocation must be one more than the nonce of the last accommodation.
+     * - The provided array of relocations must not be empty.
+     * - This bridge must support accommodations from the chain with the provided ID.
+     * - All the provided relocations must have non-zero account address.
+     * - All the provided relocations must have non-zero token amount.
+     * - If operation mode of accommodations from the chain with the provided ID is BurnAndMint
+     *   the underlying token contract must support this bridge and must execute minting operations successfully.
+     */
+    function accommodate(
+        uint256 chainId,
+        uint256 nonce,
+        Relocation[] memory relocations
+    ) external whenNotPaused onlyRole(BRIDGER_ROLE) {
+        if (_accommodationModes[chainId] == OperationMode.Unsupported) {
+            revert UnsupportedAccommodation();
+        }
+        if (nonce == 0) {
+            revert ZeroAccommodationNonce();
+        }
+        if (_lastAccommodationNonces[chainId] != (nonce - 1)) {
+            revert AccommodationNonceMismatch();
+        }
+        if (relocations.length == 0) {
+            revert EmptyRelocationArray();
+        }
+        OperationMode mode = _accommodationModes[chainId];
+        if (mode == OperationMode.BurnOrMint) {
+            if (!IERC20Bridgeable(_token).isBridgeSupported(address(this))) {
+                revert UnsupportingToken();
+            }
+        }
+
+        for (uint256 i = 0; i < relocations.length; i++) {
+            Relocation memory relocation = relocations[i];
+            if (relocation.account == address(0)) {
+                revert ZeroAccommodationAccount();
+            }
+            if (relocation.amount == 0) {
+                revert ZeroAccommodationAmount();
+            }
+            if (!relocation.canceled) {
+                accommodateInternal(relocation, mode);
+                emit Accommodate(
+                    chainId,
+                    relocation.account,
+                    relocation.amount,
+                    nonce,
+                    mode
+                );
+            }
+            nonce += 1;
+        }
+
+        _lastAccommodationNonces[chainId] = nonce - 1;
+    }
+
+    /**
+     * @dev Sets the mode of relocation to a destination chain.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {OWNER_ROLE} role.
+     * - The new relocation mode must defer from the current one.
+     * - If the new relocation mode is BurnOrMint the underlying token contract must support the bridge operations.
+     *
+     * Emits a {SetRelocationMode} event.
+     *
+     * @param chainId The ID of the destination chain to relocate to.
+     * @param newMode The new relocation mode.
+     */
+    function setRelocationMode(uint256 chainId, OperationMode newMode) external onlyRole(OWNER_ROLE) {
+        OperationMode oldMode = _relocationModes[chainId];
+        if (oldMode == newMode) {
+            return;
+        }
+        if (newMode == OperationMode.BurnOrMint) {
+            if (!isTokenIERC20BridgeableInternal(_token)) {
+                revert NonBridgeableToken();
+            }
+        }
+        _relocationModes[chainId] = newMode;
+        emit SetRelocationMode(chainId, oldMode, newMode);
+    }
+
+    /**
+     * @dev Sets the mode of accommodation from a source chain.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {OWNER_ROLE} role.
+     * - The new accommodation mode must defer from the current one.
+     * - If the new accommodation mode is BurnOrMint the underlying token contract must support the bridge operations.
+     *
+     * Emits a {SetAccommodationMode} event.
+     *
+     * @param chainId The ID of the source chain to accommodate from.
+     * @param newMode The new accommodation mode.
+     */
+    function setAccommodationMode(uint256 chainId, OperationMode newMode) external onlyRole(OWNER_ROLE) {
+        OperationMode oldMode = _accommodationModes[chainId];
+        if (oldMode == newMode) {
+            return;
+        }
+        if (newMode == OperationMode.BurnOrMint) {
+            if (!isTokenIERC20BridgeableInternal(_token)) {
+                revert NonBridgeableToken();
+            }
+        }
+        _accommodationModes[chainId] = newMode;
+        emit SetAccommodationMode(chainId, oldMode, newMode);
+    }
+
+    function cancelRelocationInternal(uint256 chainId, uint256 nonce) internal {
+        uint256 lastProcessedRelocationNonce = _lastProcessedRelocationNonces[chainId];
+        if (nonce <= lastProcessedRelocationNonce) {
+            revert AlreadyProcessedRelocation();
+        }
+        if (nonce > lastProcessedRelocationNonce + _pendingRelocationCounters[chainId]) {
+            revert NotExistentRelocation();
+        }
+
+        Relocation storage relocation = _relocations[chainId][nonce];
+
+        if (relocation.canceled) {
+            revert AlreadyCanceledRelocation();
+        }
+
+        relocation.canceled = true;
+        IERC20Upgradeable(_token).safeTransfer(relocation.account, relocation.amount);
+
+        emit CancelRelocation(
+            chainId,
+            relocation.account,
+            relocation.amount,
+            nonce
+        );
+    }
+
+    function relocateInternal(Relocation memory relocation, OperationMode mode) internal {
+        if (mode == OperationMode.BurnOrMint) {
+            bool burningSuccess = IERC20Bridgeable(_token).burnForBridging(
+                relocation.account,
+                relocation.amount
+            );
+            if (!burningSuccess) {
+                revert TokenBurningFailure();
+            }
+        } else {
+            // Do nothing, tokens are locked on the bridge account
+        }
+    }
+
+    function accommodateInternal(Relocation memory relocation, OperationMode mode) internal {
+        if (mode == OperationMode.BurnOrMint) {
+            bool mintingSuccess = IERC20Bridgeable(_token).mintForBridging(
+                relocation.account,
+                relocation.amount
+            );
+            if (!mintingSuccess) {
+                revert TokenMintingFailure();
+            }
+        } else {
+            IERC20Upgradeable(_token).safeTransfer(relocation.account, relocation.amount);
+        }
+    }
+
+    // Safely call the appropriate function from the IERC20Bridgeable interface.
+    function isTokenIERC20BridgeableInternal(address token_) internal virtual returns (bool) {
+        (bool success, bytes memory result) = token_.staticcall(abi.encodeWithSignature("isIERC20Bridgeable()"));
+        if (success && result.length > 0) {
+            return abi.decode(result, (bool));
+        } else {
+            return false;
+        }
+    }
+}

--- a/contracts/TokenBridgeStorage.sol
+++ b/contracts/TokenBridgeStorage.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { ITokenBridgeTypes } from "./interfaces/ITokenBridge.sol";
+
+/**
+ * @title TokenBridge storage version 1
+ * @dev See terms in the comments of the {ITokenBridge} interface.
+ */
+abstract contract TokenBridgeStorageV1 is ITokenBridgeTypes {
+    /// @dev The address of the underlying token contract whose coins are being relocated.
+    address internal _token;
+
+    /// @dev The mapping: a destination chain ID => the number of pending relocations to that chain.
+    mapping(uint256 => uint256) internal _pendingRelocationCounters;
+
+    /// @dev The mapping: a destination chain ID => the nonce of the last processed relocation to that chain.
+    mapping(uint256 => uint256) internal _lastProcessedRelocationNonces;
+
+    /// @dev The mapping: a destination chain ID => the mode of relocation to that chain.
+    mapping(uint256 => OperationMode) internal _relocationModes;
+
+    /// @dev The mapping: a destination chain ID, a nonce => the relocation structure matching to that chain and nonce.
+    mapping(uint256 => mapping(uint256 => Relocation)) internal _relocations;
+
+    /// @dev The mapping: a source chain ID => the mode of accommodation from that chain.
+    mapping(uint256 => OperationMode) internal _accommodationModes;
+
+    /// @dev The mapping: a source chain ID => the nonce of the last accommodation from that chain.
+    mapping(uint256 => uint256) internal _lastAccommodationNonces;
+}
+
+/**
+ * @title TokenBridge storage
+ * @dev Contains storage variables of the single token bridge contract.
+ *
+ * We are following Compound's approach of upgrading new contract implementations.
+ * See https://github.com/compound-finance/compound-protocol.
+ * When we need to add new storage variables, we create a new version of TokenBridgeStorage
+ * e.g. TokenBridgeStorage<versionNumber>, so finally it would look like
+ * "contract TokenBridgeStorage is TokenBridgeStorageV1, TokenBridgeStorageV2".
+ */
+abstract contract TokenBridgeStorage is TokenBridgeStorageV1 {
+
+}

--- a/contracts/base/PauseControlUpgradeable.sol
+++ b/contracts/base/PauseControlUpgradeable.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+
+/**
+ * @title PauseControlUpgradeable base contract
+ * @dev Extends OpenZeppelin's PausableUpgradeable contract and AccessControlUpgradeable contract.
+ * Introduces the {PAUSER_ROLE} role to control the paused state the contract that is inherited from this one.
+ * The admins of the {PAUSER_ROLE} roles are accounts with the role defined in the init() function.
+ */
+abstract contract PauseControlUpgradeable is AccessControlUpgradeable, PausableUpgradeable {
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    function __PauseControl_init(bytes32 pauserRoleAdmin) internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __Pausable_init_unchained();
+        __PauseControl_init_unchained(pauserRoleAdmin);
+    }
+
+    function __PauseControl_init_unchained(bytes32 pauserRoleAdmin) internal onlyInitializing {
+        _setRoleAdmin(PAUSER_ROLE, pauserRoleAdmin);
+    }
+
+    /**
+     * @dev Triggers the paused state of the contract.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller should have the {PAUSER_ROLE} role.
+     *
+     * Emits a {Paused} event if it is executed successfully.
+     */
+    function pause() external onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    /**
+     * @dev Triggers the unpaused state.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     * - The caller should have the {PAUSER_ROLE} role.
+     *
+     * Emits a {Unpaused} event if it is executed successfully.
+     */
+    function unpause() external onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[50] private __gap;
+}

--- a/contracts/base/RescueControlUpgradeable.sol
+++ b/contracts/base/RescueControlUpgradeable.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+/**
+ * @title RescueControlUpgradeable base contract
+ * @dev Allows to "rescue" tokens locked up in the contract by transferring to a specified address.
+ * Only accounts that have the {RESCUER_ROLE} role can execute token transferring operations.
+ * The admins of the {RESCUER_ROLE} roles are accounts with the role defined in the init() function.
+ */
+abstract contract RescueControlUpgradeable is AccessControlUpgradeable {
+    bytes32 public constant RESCUER_ROLE = keccak256("RESCUER_ROLE");
+
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    function __RescueControl_init(bytes32 rescuerRoleAdmin) internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __RescueControl_init_unchained(rescuerRoleAdmin);
+    }
+
+    function __RescueControl_init_unchained(bytes32 rescuerRoleAdmin) internal onlyInitializing {
+        _setRoleAdmin(RESCUER_ROLE, rescuerRoleAdmin);
+    }
+
+    /**
+     * @dev Rescue ERC20 tokens locked up in this contract.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {RESCUER_ROLE} role.
+     *
+     * @param tokenContract The ERC20 token contract address.
+     * @param to The recipient address.
+     * @param amount The amount to withdraw.
+     */
+    function rescueERC20(
+        IERC20Upgradeable tokenContract,
+        address to,
+        uint256 amount
+    ) external onlyRole(RESCUER_ROLE) {
+        tokenContract.safeTransfer(to, amount);
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[50] private __gap;
+}

--- a/contracts/base/StoragePlaceholder.sol
+++ b/contracts/base/StoragePlaceholder.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.9.0;
+
+/**
+ * @title StoragePlaceholder150 abstract contract
+ * @dev Reserves 200 storage slots.
+ * Such a storage placeholder contract allows future replacement of it with other contracts
+ * without shifting down storage in the inheritance chain.
+ *
+ * E.g. the following code:
+ * ```
+ * abstract contract StoragePlaceholder200 {
+ *     uint256[200] private __gap;
+ * }
+ *
+ * contract A is B, StoragePlaceholder200, C {
+ *     //Some implementation
+ * }
+ * ```
+ * can be replaced with the following code without a storage shifting issue:
+ * ```
+ * abstract contract StoragePlaceholder150 {
+ *     uint256[150] private __gap;
+ * }
+ *
+ * abstract contract X {
+ *     uint256[50] public values;
+ *     // No more storage variables. Some set of functions should be here.
+ * }
+ *
+ * contract A is B, X, StoragePlaceholder150, C {
+ *     //Some implementation
+ * }
+ * ```
+ */
+abstract contract StoragePlaceholder200 {
+    uint256[200] private __gap;
+}

--- a/contracts/interfaces/IERC20Bridgeable.sol
+++ b/contracts/interfaces/IERC20Bridgeable.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+/**
+ * @title IERC20Bridgeable interface
+ * @dev The interface of a token that supports the bridge operations.
+ */
+interface IERC20Bridgeable {
+    /// @dev Emitted when a minting operation is performed as part of a bridge operation.
+    event MintForBridging(address indexed account, uint256 amount);
+    /// @dev Emitted when a burning operation is performed as part of a bridge operation.
+    event BurnForBridging(address indexed account, uint256 amount);
+
+    /**
+     * @dev Mints tokens as part of a bridge operation.
+     * It is expected that this function can be called only by a bridge contract.
+     *
+     * Emits a {MintForBridging} event.
+     *
+     * @param account The owner of the tokens passing through the bridge.
+     * @param amount The amount of tokens passing through the bridge.
+     * @return True if the operation was successful.
+     */
+    function mintForBridging(address account, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Burns tokens as part of a bridge operation.
+     * It is expected that this function can be called only by a bridge contract.
+     *
+     * Emits a {BurnForBridging} event.
+     *
+     * @param account The owner of the tokens passing through the bridge.
+     * @param amount The amount of tokens passing through the bridge.
+     * @return True if the operation was successful.
+     */
+    function burnForBridging(address account, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Checks whether a bridge is supported by the token or not.
+     * @param bridge The address of the bridge to check.
+     * @return True if the bridge is supported by the token.
+     */
+    function isBridgeSupported(address bridge) external view returns (bool);
+
+    /**
+     * @dev Checks whether the token supports the bridge operations by implementing this interface.
+     * @return True in any case.
+     */
+    function isIERC20Bridgeable() external view returns (bool);
+}

--- a/contracts/interfaces/IMultiTokenBridge.sol
+++ b/contracts/interfaces/IMultiTokenBridge.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+/**
+ * @title MultiTokenBridge types interface
+ * @dev See terms in the comments of the {IMultiTokenBridge} interface.
+ */
+interface IMultiTokenBridgeTypes {
+    /**
+     * @dev Enumeration for bridge operation mode
+     */
+    enum OperationMode {
+        Unsupported,   // 0 Relocation/accommodation with certain parameters is unsupported (the default value).
+        BurnOrMint,    // 1 Relocation/accommodation is supported with token burning/minting during the op.
+        LockOrTransfer // 2 Relocation/accommodation is supported with token locking/transferring during the op.
+    }
+
+    /**
+     * @dev Structure with data of a single token relocation.
+     */
+    struct Relocation {
+        address token;   // The address of the token contract whose coins are being relocated.
+        address account; // The account who requested the relocation.
+        uint256 amount;  // The amount of tokens to relocate.
+        bool canceled;   // The state of the relocation.
+    }
+}
+
+/**
+ * @title MultiTokenBridge interface
+ * @dev A contract implementing this interface allows to bridge coins of multiple token contracts between blockchains.
+ *
+ * Terms that are used in relation to bridge contracts:
+ *
+ * - relocation -- the relocation of tokens from one chain (a source chain) to another one (a destination chain).
+                   Unless otherwise stated, the source chain is the current chain.
+ * - to relocate -- to move tokens from the current chain to another one.
+ * - accommodation -- placing tokens coming from another chain in the current chain.
+ * - to accommodate -- to meet a relocation coming from another chain and place its tokens in the current chain.
+ */
+interface IMultiTokenBridge is IMultiTokenBridgeTypes {
+    /// @dev Emitted when a new relocation is requested by an account.
+    event RequestRelocation(
+        uint256 indexed chainId, // The destination chain ID of the relocation.
+        address indexed token,   // The address of the token contract whose coins are being relocated.
+        address indexed account, // The account who requested the relocation.
+        uint256 amount,          // The amount of tokens to relocate.
+        uint256 nonce            // The relocation nonce.
+    );
+
+    /// @dev Emitted when a pending relocation is canceled.
+    event CancelRelocation(
+        uint256 indexed chainId, // The destination chain ID of the relocation.
+        address indexed token,   // The address of the token contract whose coins are being relocated.
+        address indexed account, // The account who requested the relocation.
+        uint256 amount,          // The amount of tokens to relocate.
+        uint256 nonce            // The relocation nonce.
+    );
+
+    /// @dev Emitted when a previously requested and non-canceled relocation is processed.
+    event Relocate(
+        uint256 indexed chainId, // The destination chain ID of the relocation.
+        address indexed token,   // The address of the token contract whose coins are being relocated.
+        address indexed account, // The account who requested the relocation.
+        uint256 amount,          // The amount of tokens to relocate.
+        uint256 nonce,           // The relocation nonce.
+        OperationMode mode       // The mode of the relocation.
+    );
+
+    /// @dev Emitted when a new accommodation takes place.
+    event Accommodate(
+        uint256 indexed chainId, // The source chain ID of the accommodation.
+        address indexed token,   // The address of the token contract whose coins are being accommodated.
+        address indexed account, // The account who requested the correspondent relocation in the source chain.
+        uint256 amount,          // The amount of tokens to relocate.
+        uint256 nonce,           // The accommodation nonce.
+        OperationMode mode       // The mode of the accommodation.
+    );
+
+    /**
+     * @dev Returns the counter of pending relocations to a destination chain with a given ID.
+     * @param chainId The ID of the destination chain.
+     */
+    function getPendingRelocationCounter(uint256 chainId) external view returns (uint256);
+
+    /**
+     * @dev Returns the nonce of the last processed relocation to a destination chain with a given ID.
+     * @param chainId The ID of the destination chain.
+     */
+    function getLastProcessedRelocationNonce(uint256 chainId) external view returns (uint256);
+
+    /**
+     * @dev Returns mode of relocation to a destination chain with a given ID and for a given token.
+     * @param chainId The ID of the destination chain.
+     * @param token The address of the token contract whose coins are being relocated.
+     */
+    function getRelocationMode(uint256 chainId, address token) external view returns (OperationMode);
+
+    /**
+     * @dev Returns a relocation for a given destination chain ID and nonce.
+     * @param chainId The ID of the destination chain.
+     * @param nonce The nonce of the relocation to return.
+     */
+    function getRelocation(uint256 chainId, uint256 nonce) external view returns (Relocation memory);
+
+    /**
+     * @dev Returns mode of accommodation from a source chain with a given ID and for a given token.
+     * @param chainId The ID of the source chain.
+     * @param token The address of the token contract whose coins are being accommodated.
+     */
+    function getAccommodationMode(uint256 chainId, address token) external view returns (OperationMode);
+
+    /**
+     * @dev Returns the last nonce of an accommodation from a source chain with a given ID.
+     * @param chainId The ID of the source chain.
+     */
+    function getLastAccommodationNonce(uint256 chainId) external view returns (uint256);
+
+    /**
+     * @dev Returns the relocations for a given destination chain id and a range of nonces.
+     * @param chainId The ID of the destination chain.
+     * @param nonce The first nonce of the relocation range to return.
+     * @param count The number of relocations in the range to return.
+     * @return relocations The array of relocations for the requested range.
+     */
+    function getRelocations(
+        uint256 chainId,
+        uint256 nonce,
+        uint256 count
+    ) external view returns (Relocation[] memory relocations);
+
+    /**
+     * @dev Requests a new relocation with transferring tokens from an account to the bridge.
+     * The new relocation will be pending until it is processed.
+     * This function is expected to be called by any account.
+     *
+     * Emits a {RequestRelocation} event.
+     *
+     * @param chainId The ID of the destination chain.
+     * @param token The address of the token contract whose coins are being relocated.
+     * @param amount The amount of tokens to relocate.
+     * @return nonce The nonce of the new relocation.
+     */
+    function requestRelocation(
+        uint256 chainId,
+        address token,
+        uint256 amount
+    ) external returns (uint256 nonce);
+
+    /**
+     * @dev Cancels a pending relocation with transferring tokens back from the bridge to the account.
+     * This function is expected to be called by the same account who request the relocation.
+     *
+     * Emits a {CancelRelocation} event.
+     *
+     * @param chainId The destination chain ID of the relocation to cancel.
+     * @param nonce The nonce of the pending relocation to cancel.
+     */
+    function cancelRelocation(uint256 chainId, uint256 nonce) external;
+
+    /**
+     * @dev Cancels multiple pending relocations with transferring tokens back from the bridge to the accounts.
+     * This function can be called by a limited number of accounts that are allowed to execute bridge operations.
+     *
+     * Emits a {CancelRelocation} event for each relocation.
+     *
+     * @param chainId The destination chain ID of the relocations to cancel.
+     * @param nonces The array of pending relocation nonces to cancel.
+     */
+    function cancelRelocations(uint256 chainId, uint256[] memory nonces) external;
+
+    /**
+     * @dev Processes several pending relocations.
+     * Burns or locks tokens previously received from accounts specified in the pending relocations depending on
+     * the operation mode of each relocation.
+     * If a relocation is executed in the BurnOrMint operation mode the tokens are burnt.
+     * If a relocation is executed in the LockOrTransfer operation mode the tokens are locked on the bridge account.
+     * The canceled relocations are skipped during the processing.
+     * This function can be called by a limited number of accounts that are allowed to execute bridge operations.
+     *
+     * Emits a {Relocate} event for each non-canceled relocation.
+     *
+     * @param chainId The destination chain ID of the pending relocations to process.
+     * @param count The number of pending relocations to process.
+     */
+    function relocate(uint256 chainId, uint256 count) external;
+
+    /**
+     * @dev Accommodates tokens of several relocations coming from a source chain.
+     * Mints or transfers tokens according to passed relocation structures depending on
+     * the operation mode of each accommodation distinguished by the source chain ID and the token contract.
+     * If an accommodation is executed in the BurnOrMint operation mode the tokens are minted for
+     * the account mentioned in the related relocation structure.
+     * If an accommodation is executed in the LockOrTransfer operation mode the tokens are transferred
+     * from the bridge account to the account mentioned in the related relocation structure.
+     * Tokens will be minted or transferred only for non-canceled relocations.
+     * This function can be called by a limited number of accounts that are allowed to execute bridge operations.
+     *
+     * Emits a {Accommodate} event for each non-canceled relocation.
+     *
+     * @param chainId The ID of the source chain.
+     * @param nonce The nonce of the first relocation to accommodate.
+     * @param relocations The array of relocations to accommodate.
+     */
+    function accommodate(
+        uint256 chainId,
+        uint256 nonce,
+        Relocation[] memory relocations
+    ) external;
+}

--- a/contracts/interfaces/ITokenBridge.sol
+++ b/contracts/interfaces/ITokenBridge.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+/**
+ * @title TokenBridge types interface
+ * @dev See terms in the comments of the {IMultiTokenBridge} interface.
+ */
+interface ITokenBridgeTypes {
+    /**
+     * @dev Enumeration for bridge operation mode
+     */
+    enum OperationMode {
+        Unsupported, // 0 Relocation/accommodation with certain parameters is unsupported (the default value).
+        BurnOrMint, // 1 Relocation/accommodation is supported with token burning/minting during the op.
+        LockOrTransfer // 2 Relocation/accommodation is supported with token locking/transferring during the op.
+    }
+
+    /**
+     * @dev Structure with data of a single token relocation.
+     */
+    struct Relocation {
+        address account; // The account who requested the relocation.
+        uint256 amount;  // The amount of tokens to relocate.
+        bool canceled;   // The state of the relocation.
+    }
+}
+
+/**
+ * @title TokenBridge interface
+ * @dev A contract implementing this interface allows to bridge coins of a single token contract between blockchains.
+ *
+ * Terms that are used in relation to bridge contracts:
+ *
+ * - relocation -- the relocation of tokens from one chain (a source chain) to another one (a destination chain).
+                   Unless otherwise stated, the source chain is the current chain.
+ * - to relocate -- to move tokens from the current chain to another one.
+ * - accommodation -- placing tokens coming from another chain in the current chain.
+ * - to accommodate -- to meet a relocation coming from another chain and place its tokens in the current chain.
+ */
+interface ITokenBridge is ITokenBridgeTypes {
+    /// @dev Emitted when a new relocation is requested by an account.
+    event RequestRelocation(
+        uint256 indexed chainId, // The destination chain ID of the relocation.
+        address indexed account, // The account who requested the relocation.
+        uint256 amount,          // The amount of tokens to relocate.
+        uint256 nonce            // The relocation nonce.
+    );
+
+    /// @dev Emitted when a pending relocation is canceled.
+    event CancelRelocation(
+        uint256 indexed chainId, // The destination chain ID of the relocation.
+        address indexed account, // The account who requested the relocation.
+        uint256 amount,          // The amount of tokens to relocate.
+        uint256 nonce            // The relocation nonce.
+    );
+
+    /// @dev Emitted when a previously requested and non-canceled relocation is processed.
+    event Relocate(
+        uint256 indexed chainId, // The destination chain ID of the relocation.
+        address indexed account, // The account who requested the relocation.
+        uint256 amount,          // The amount of tokens to relocate.
+        uint256 nonce,           // The relocation nonce.
+        OperationMode mode       // The mode of the relocation.
+    );
+
+    /// @dev Emitted when a new accommodation takes place.
+    event Accommodate(
+        uint256 indexed chainId, // The source chain ID of the accommodation.
+        address indexed account, // The account who requested the correspondent relocation in the source chain.
+        uint256 amount,          // The amount of tokens to relocate.
+        uint256 nonce,           // The accommodation nonce.
+        OperationMode mode       // The mode of the accommodation.
+    );
+
+    /**
+     * @dev Returns the address of the underlying token contract.
+     */
+    function underlyingToken() external view returns (address);
+
+    /**
+     * @dev Returns the counter of pending relocations to a destination chain with a given ID.
+     * @param chainId The ID of the destination chain.
+     */
+    function getPendingRelocationCounter(uint256 chainId) external view returns (uint256);
+
+    /**
+     * @dev Returns the nonce of the last processed relocation to a destination chain with a given ID.
+     * @param chainId The ID of the destination chain.
+     */
+    function getLastProcessedRelocationNonce(uint256 chainId) external view returns (uint256);
+
+    /**
+     * @dev Returns mode of relocation to a destination chain with a given ID.
+     * @param chainId The ID of the destination chain.
+     */
+    function getRelocationMode(uint256 chainId) external view returns (OperationMode);
+
+    /**
+     * @dev Returns a relocation for a given destination chain ID and nonce.
+     * @param chainId The ID of the destination chain.
+     * @param nonce The nonce of the relocation to return.
+     */
+    function getRelocation(uint256 chainId, uint256 nonce) external view returns (Relocation memory);
+
+    /**
+     * @dev Returns mode of accommodation from a source chain with a given ID.
+     * @param chainId The ID of the source chain.
+     */
+    function getAccommodationMode(uint256 chainId) external view returns (OperationMode);
+
+    /**
+     * @dev Returns the last nonce of an accommodation from a source chain with a given ID.
+     * @param chainId The ID of the source chain.
+     */
+    function getLastAccommodationNonce(uint256 chainId) external view returns (uint256);
+
+    /**
+     * @dev Returns the relocations for a given destination chain id and a range of nonces.
+     * @param chainId The ID of the destination chain.
+     * @param nonce The first nonce of the relocation range to return.
+     * @param count The number of relocations in the range to return.
+     * @return relocations The array of relocations for the requested range.
+     */
+    function getRelocations(
+        uint256 chainId,
+        uint256 nonce,
+        uint256 count
+    ) external view returns (Relocation[] memory relocations);
+
+    /**
+     * @dev Requests a new relocation with transferring tokens from an account to the bridge.
+     * The new relocation will be pending until it is processed.
+     * This function is expected to be called by any account.
+     *
+     * Emits a {RequestRelocation} event.
+     *
+     * @param chainId The ID of the destination chain.
+     * @param amount The amount of tokens to relocate.
+     * @return nonce The nonce of the new relocation.
+     */
+    function requestRelocation(uint256 chainId, uint256 amount) external returns (uint256 nonce);
+
+    /**
+     * @dev Cancels a pending relocation with transferring tokens back from the bridge to the account.
+     * This function is expected to be called by the same account who request the relocation.
+     *
+     * Emits a {CancelRelocation} event.
+     *
+     * @param chainId The destination chain ID of the relocation to cancel.
+     * @param nonce The nonce of the pending relocation to cancel.
+     */
+    function cancelRelocation(uint256 chainId, uint256 nonce) external;
+
+    /**
+     * @dev Cancels multiple pending relocations with transferring tokens back from the bridge to the accounts.
+     * This function can be called by a limited number of accounts that are allowed to execute bridge operations.
+     *
+     * Emits a {CancelRelocation} event for each relocation.
+     *
+     * @param chainId The destination chain ID of the relocations to cancel.
+     * @param nonces The array of pending relocation nonces to cancel.
+     */
+    function cancelRelocations(uint256 chainId, uint256[] memory nonces) external;
+
+    /**
+     * @dev Processes several pending relocations.
+     * Burns or locks tokens previously received from accounts specified in the pending relocations depending on
+     * the operation mode of relocations.
+     * If relocations are executed in the BurnOrMint operation mode the tokens are burnt.
+     * If relocations are executed in the LockOrTransfer operation mode the tokens are locked on the bridge account.
+     * The canceled relocations are skipped during the processing.
+     * This function can be called by a limited number of accounts that are allowed to execute bridge operations.
+     *
+     * Emits a {Relocate} event for each non-canceled relocation.
+     *
+     * @param chainId The destination chain ID of the pending relocations to process.
+     * @param count The number of pending relocations to process.
+     */
+    function relocate(uint256 chainId, uint256 count) external;
+
+    /**
+     * @dev Accommodates tokens of several relocations coming from a source chain.
+     * Mints or transfers tokens according to passed relocation structures depending on
+     * the operation mode accommodations.
+     * If accommodations are executed in the BurnOrMint operation mode the tokens are minted for
+     * the account mentioned in the related relocation structure.
+     * If accommodations are executed in the LockOrTransfer operation mode the tokens are transferred
+     * from the bridge account to the account mentioned in the related relocation structure.
+     * Tokens will be minted or transferred only for non-canceled relocations.
+     * This function can be called by a limited number of accounts that are allowed to execute bridge operations.
+     *
+     * Emits a {Accommodate} event for each non-canceled relocation.
+     *
+     * @param chainId The ID of the source chain.
+     * @param nonce The nonce of the first relocation to accommodate.
+     * @param relocations The array of relocations to accommodate.
+     */
+    function accommodate(
+        uint256 chainId,
+        uint256 nonce,
+        Relocation[] memory relocations
+    ) external;
+}

--- a/contracts/mocks/base/PauseControlUpgradeableMock.sol
+++ b/contracts/mocks/base/PauseControlUpgradeableMock.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { PauseControlUpgradeable } from "../../base/PauseControlUpgradeable.sol";
+
+/**
+ * @title PauseControlUpgradeableMock contract
+ * @dev An implementation of the {PauseControlUpgradeable} contract for test purposes.
+ */
+contract PauseControlUpgradeableMock is PauseControlUpgradeable {
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @dev The initialize function of the upgradable contract.
+    function initialize() public initializer {
+        _setupRole(OWNER_ROLE, _msgSender());
+        __PauseControl_init(OWNER_ROLE);
+    }
+
+    /// @dev To check that the initialize function of the ancestor contract has the 'onlyInitializing' modifier.
+    function call_parent_initialize() public {
+        __PauseControl_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev To check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __PauseControl_init_unchained(OWNER_ROLE);
+    }
+}

--- a/contracts/mocks/base/RescueControlUpgradeableMock.sol
+++ b/contracts/mocks/base/RescueControlUpgradeableMock.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { RescueControlUpgradeable } from "../../base/RescueControlUpgradeable.sol";
+
+/**
+ * @title RescueControlUpgradeableMock contract
+ * @dev An implementation of the {RescueControlUpgradeable} contract for test purposes.
+ */
+contract RescueControlUpgradeableMock is RescueControlUpgradeable {
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @dev The initialize function of the upgradable contract.
+    function initialize() public initializer {
+        _setupRole(OWNER_ROLE, _msgSender());
+        __RescueControl_init(OWNER_ROLE);
+    }
+
+    /// @dev To check that the initialize function of the ancestor contract has the 'onlyInitializing' modifier.
+    function call_parent_initialize() public {
+        __RescueControl_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev To check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __RescueControl_init_unchained(OWNER_ROLE);
+    }
+}

--- a/contracts/mocks/tokens/ERC20UpgradeableMock.sol
+++ b/contracts/mocks/tokens/ERC20UpgradeableMock.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+
+import { IERC20Bridgeable } from "../../interfaces/IERC20Bridgeable.sol";
+
+/**
+ * @title ERC20UpgradeableMock contract
+ * @dev An implementation of the {ERC20Upgradeable} contract for test purposes.
+ */
+contract ERC20UpgradeableMock is ERC20Upgradeable, IERC20Bridgeable {
+    address private _bridge;
+    bool private _isMintingForBridgingDisabled;
+    bool private _isBurningForBridgingDisabled;
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     * @param name_ The name of the token to set for this ERC20-comparable contract.
+     * @param symbol_ The symbol of the token to set for this ERC20-comparable contract.
+     */
+    function initialize(string memory name_, string memory symbol_) public initializer {
+        __ERC20_init(name_, symbol_);
+    }
+
+    /**
+     * @dev Cals the appropriate internal function to mint needed amount of tokens for an account.
+     * @param account The address of an account to mint for.
+     * @param amount The amount of tokens to mint.
+     */
+    function mint(address account, uint256 amount) external returns (bool) {
+        _mint(account, amount);
+        return true;
+    }
+
+    /// @dev See {IERC20Bridgeable-mintForBridging}.
+    function mintForBridging(address account, uint256 amount) external override returns (bool) {
+        if (_isMintingForBridgingDisabled) {
+            return false;
+        }
+        _mint(account, amount);
+        emit MintForBridging(account, amount);
+        return true;
+    }
+
+    /// @dev See {IERC20Bridgeable-burnForBridging}.
+    function burnForBridging(address account, uint256 amount) external override returns (bool) {
+        if (_isBurningForBridgingDisabled) {
+            return false;
+        }
+        _burn(msg.sender, amount);
+        emit BurnForBridging(account, amount);
+        return true;
+    }
+
+    /// @dev See {IERC20Bridgeable-isBridgeSupported}.
+    function isBridgeSupported(address bridge) public view override returns (bool) {
+        return (bridge != address(0)) && (_bridge == bridge);
+    }
+
+    /// @dev See {IERC20Bridgeable-isIERC20Bridgeable}.
+    function isIERC20Bridgeable() public pure override returns (bool) {
+        return true;
+    }
+
+    /**
+     * @dev Sets the address of the bridge.
+     * @param newBridge The address of the new bridge.
+     */
+    function setBridge(address newBridge) external {
+        _bridge = newBridge;
+    }
+
+    /// @dev Disables token minting for bridging operations.
+    function disableMintingForBridging() external {
+        _isMintingForBridgingDisabled = true;
+    }
+
+    /// @dev Disables token burning for bridging operations.
+    function disableBurningForBridging() external {
+        _isBurningForBridgingDisabled = true;
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -4,7 +4,7 @@ import "@openzeppelin/hardhat-upgrades";
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.15",
+    version: "0.8.16",
     settings: {
       optimizer: {
         enabled: true,
@@ -31,6 +31,9 @@ const config: HardhatUserConfig = {
       },
       gas: "auto"
     },
+  },
+  mocha: {
+    timeout: 120000
   },
 };
 

--- a/test-utils/README.md
+++ b/test-utils/README.md
@@ -1,0 +1,3 @@
+## Test utils directory
+
+This directory contains some custom utilities used in the tests

--- a/test-utils/eth.ts
+++ b/test-utils/eth.ts
@@ -1,0 +1,6 @@
+import { TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
+
+export async function proveTx(txResponsePromise: Promise<TransactionResponse>): Promise<TransactionReceipt> {
+  const txReceipt = await txResponsePromise;
+  return txReceipt.wait();
+}

--- a/test-utils/misc.ts
+++ b/test-utils/misc.ts
@@ -1,0 +1,14 @@
+function countNumberArrayTotal(array: number[]) {
+  return array.reduce((sum: number, currentValue: number) => {
+    return sum + currentValue;
+  });
+}
+
+function createRevertMessageDueToMissingRole(address: string, role: string) {
+  return `AccessControl: account ${address.toLowerCase()} is missing role ${role.toLowerCase()}`;
+}
+
+export {
+  countNumberArrayTotal,
+  createRevertMessageDueToMissingRole
+};

--- a/test/MultiTokenBridge.test.ts
+++ b/test/MultiTokenBridge.test.ts
@@ -1,0 +1,1674 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../test-utils/eth";
+import { countNumberArrayTotal, createRevertMessageDueToMissingRole } from "../test-utils/misc";
+
+enum OperationMode {
+  Unsupported = 0,
+  BurnOrMint = 1,
+  LockOrTransfer = 2,
+}
+
+interface TestTokenRelocation {
+  chainId: number;
+  token: Contract;
+  account: SignerWithAddress;
+  amount: number;
+  nonce: number;
+  requested?: boolean;
+  processed?: boolean;
+  canceled?: boolean;
+}
+
+interface OnChainRelocation {
+  token: string;
+  account: string;
+  amount: BigNumber;
+  canceled: boolean;
+}
+
+const defaultOnChainRelocation: OnChainRelocation = {
+  token: ethers.constants.AddressZero,
+  account: ethers.constants.AddressZero,
+  amount: ethers.constants.Zero,
+  canceled: false,
+};
+
+interface BridgeStateForChainId {
+  requestedRelocationCount: number;
+  processedRelocationCount: number;
+  pendingRelocationCount: number;
+  firstNonce: number;
+  nonceCount: number;
+  onChainRelocations: OnChainRelocation[];
+}
+
+function toOnChainRelocation(relocation: TestTokenRelocation): OnChainRelocation {
+  return {
+    token: relocation.token.address,
+    account: relocation.account.address,
+    amount: BigNumber.from(relocation.amount),
+    canceled: relocation.canceled || false,
+  };
+}
+
+function checkEquality(
+  actualOnChainRelocation: any,
+  expectedRelocation: OnChainRelocation,
+  relocationIndex: number,
+  chainId: number
+) {
+  expect(actualOnChainRelocation.token).to.equal(
+    expectedRelocation.token,
+    `relocation[${relocationIndex}].token is incorrect, chainId=${chainId}`
+  );
+  expect(actualOnChainRelocation.account).to.equal(
+    expectedRelocation.account,
+    `relocation[${relocationIndex}].account is incorrect, chainId=${chainId}`
+  );
+  expect(actualOnChainRelocation.amount).to.equal(
+    expectedRelocation.amount,
+    `relocation[${relocationIndex}].amount is incorrect, chainId=${chainId}`
+  );
+  expect(actualOnChainRelocation.canceled).to.equal(
+    expectedRelocation.canceled,
+    `relocation[${relocationIndex}].canceled is incorrect, chainId=${chainId}`
+  );
+}
+
+function countRelocationsForChainId(relocations: TestTokenRelocation[], targetChainId: number) {
+  return countNumberArrayTotal(
+    relocations.map(
+      function (relocation: TestTokenRelocation): number {
+        return (relocation.chainId == targetChainId) ? 1 : 0;
+      }
+    )
+  );
+}
+
+function markRelocationsAsProcessed(relocations: TestTokenRelocation[]) {
+  relocations.forEach((relocation: TestTokenRelocation) => relocation.processed = true);
+}
+
+function getAmountByTokenAndAddresses(
+  relocations: TestTokenRelocation[],
+  targetToken: Contract,
+  addresses: string[]
+): number[] {
+  const totalAmountPerAddress: Map<string, number> = new Map<string, number>();
+  relocations.forEach(relocation => {
+    const address = relocation.account.address;
+    let totalAmount = totalAmountPerAddress.get(address) || 0;
+    if (relocation.token == targetToken && !relocation.canceled) {
+      totalAmount += relocation.amount;
+    }
+    totalAmountPerAddress.set(address, totalAmount);
+  });
+  return addresses.map((address: string) => totalAmountPerAddress.get(address) || 0);
+}
+
+describe("Contract 'MultiTokenBridge'", async () => {
+  // Revert messages
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
+
+  const REVERT_ERROR_IF_TOKEN_DOES_NOT_SUPPORT_BRIDGE_OPERATIONS = "NonBridgeableToken";
+  const REVERT_ERROR_IF_RELOCATION_TOKEN_ADDRESS_IS_ZERO = "ZeroRelocationTokenAddress";
+  const REVERT_ERROR_IF_RELOCATION_AMOUNT_IS_ZERO = "ZeroRelocationAmount";
+  const REVERT_ERROR_IF_RELOCATION_IS_UNSUPPORTED = "UnsupportedRelocation";
+  const REVERT_ERROR_IF_UNSUPPORTING_TOKEN = "UnsupportingToken";
+  const REVERT_ERROR_IF_TRANSACTION_SENDER_IS_UNAUTHORIZED = "UnauthorizedTransactionSender";
+  const REVERT_ERROR_IF_RELOCATION_ARRAY_OF_NONCES_IS_EMPTY = "EmptyNonceArray";
+  const REVERT_ERROR_IF_RELOCATION_IS_ALREADY_PROCESSED = "AlreadyProcessedRelocation";
+  const REVERT_ERROR_IF_RELOCATION_DOES_NOT_EXIST = "NotExistentRelocation";
+  const REVERT_ERROR_IF_RELOCATION_IS_ALREADY_CANCELED = "AlreadyCanceledRelocation";
+  const REVERT_ERROR_IF_RELOCATION_COUNT_IS_ZERO = "ZeroRelocationCount";
+  const REVERT_ERROR_IF_THERE_IS_LACK_PENDING_RELOCATIONS = "LackOfPendingRelocations";
+  const REVERT_ERROR_IF_BURNING_OF_TOKENS_FAILED = "TokenBurningFailure";
+  const REVERT_ERROR_IF_ACCOMMODATION_IS_UNSUPPORTED = "UnsupportedAccommodation";
+  const REVERT_ERROR_IF_ACCOMMODATION_FIRST_NONCE_IS_ZERO = "ZeroAccommodationNonce";
+  const REVERT_ERROR_IF_ACCOMMODATION_NONCE_MISMATCH = "AccommodationNonceMismatch";
+  const REVERT_ERROR_IF_INPUT_ARRAY_OF_RELOCATIONS_IS_EMPTY = "EmptyRelocationArray";
+  const REVERT_ERROR_IF_ACCOMMODATION_ACCOUNT_IS_ZERO_ADDRESS = "ZeroAccommodationAccount";
+  const REVERT_ERROR_IF_ACCOMMODATION_AMOUNT_IS_ZERO = "ZeroAccommodationAmount";
+  const REVERT_ERROR_IF_MINTING_OF_TOKENS_FAILED = "TokenMintingFailure";
+
+  let multiTokenBridge: Contract;
+  let fakeTokenAddress: string;
+  let deployer: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+  let ownerRole: string;
+  let pauserRole: string;
+  let rescuerRole: string;
+  let bridgerRole: string;
+  let operationMode: OperationMode;
+
+  async function deployTokenMock(serialNumber: number): Promise<Contract> {
+    const name = "BRL Coin " + serialNumber;
+    const symbol = "BRLC" + serialNumber;
+    const TokenMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    const tokenMock: Contract = await TokenMock.deploy();
+    await tokenMock.deployed();
+    await proveTx(tokenMock.initialize(name, symbol));
+
+    // Set the supported bridge of the token if it is needed
+    if (operationMode == OperationMode.BurnOrMint) {
+      await proveTx(tokenMock.setBridge(multiTokenBridge.address));
+    }
+    return tokenMock;
+  }
+
+  async function setUpContractsForRelocations(relocations: TestTokenRelocation[]) {
+    for (const relocation of relocations) {
+      const relocationMode: OperationMode = await multiTokenBridge.getRelocationMode(
+        relocation.chainId,
+        relocation.token.address
+      );
+      if (relocationMode !== operationMode) {
+        await proveTx(
+          multiTokenBridge.setRelocationMode(
+            relocation.chainId,
+            relocation.token.address,
+            operationMode
+          )
+        );
+      }
+      await proveTx(relocation.token.mint(relocation.account.address, relocation.amount));
+      const allowance: BigNumber =
+        await relocation.token.allowance(relocation.account.address, multiTokenBridge.address);
+      if (allowance.lt(BigNumber.from(ethers.constants.MaxUint256))) {
+        await proveTx(
+          relocation.token.connect(relocation.account).approve(
+            multiTokenBridge.address,
+            ethers.constants.MaxUint256
+          )
+        );
+      }
+    }
+  }
+
+  async function requestRelocations(relocations: TestTokenRelocation[]) {
+    for (const relocation of relocations) {
+      await proveTx(
+        multiTokenBridge.connect(relocation.account).requestRelocation(
+          relocation.chainId,
+          relocation.token.address,
+          relocation.amount)
+      );
+      relocation.requested = true;
+    }
+  }
+
+  async function pauseMultiTokenBridge() {
+    await proveTx(multiTokenBridge.grantRole(pauserRole, deployer.address));
+    await proveTx(multiTokenBridge.pause());
+  }
+
+  async function setBridgerRole(account: SignerWithAddress) {
+    await proveTx(multiTokenBridge.grantRole(bridgerRole, account.address));
+  }
+
+  async function cancelRelocations(relocations: TestTokenRelocation[]) {
+    for (const relocation of relocations) {
+      await proveTx(
+        multiTokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce)
+      );
+      relocation.canceled = true;
+    }
+  }
+
+  function defineExpectedChainIds(relocations: TestTokenRelocation[]): Set<number> {
+    const expectedChainIds: Set<number> = new Set<number>();
+
+    relocations.forEach((relocation: TestTokenRelocation) => {
+      expectedChainIds.add(relocation.chainId);
+    });
+
+    return expectedChainIds;
+  }
+
+  function defineExpectedTokens(relocations: TestTokenRelocation[]): Set<Contract> {
+    const expectedTokens: Set<Contract> = new Set<Contract>();
+
+    relocations.forEach((relocation: TestTokenRelocation) => {
+      expectedTokens.add(relocation.token);
+    });
+
+    return expectedTokens;
+  }
+
+  function defineExpectedBridgeStateForSingleChainId(
+    chainId: number,
+    relocations: TestTokenRelocation[]
+  ): BridgeStateForChainId {
+    const expectedBridgeState: BridgeStateForChainId = {
+      requestedRelocationCount: 0,
+      processedRelocationCount: 0,
+      pendingRelocationCount: 0,
+      firstNonce: 0,
+      nonceCount: 1,
+      onChainRelocations: [defaultOnChainRelocation]
+    };
+    expectedBridgeState.requestedRelocationCount = countNumberArrayTotal(
+      relocations.map(
+        function (relocation: TestTokenRelocation): number {
+          return !!relocation.requested && relocation.chainId == chainId ? 1 : 0;
+        }
+      )
+    );
+
+    expectedBridgeState.processedRelocationCount = countNumberArrayTotal(
+      relocations.map(
+        function (relocation: TestTokenRelocation): number {
+          return !!relocation.processed && relocation.chainId == chainId ? 1 : 0;
+        }
+      )
+    );
+
+    relocations.forEach((relocation: TestTokenRelocation) => {
+      if (!!relocation.requested && relocation.chainId == chainId) {
+        expectedBridgeState.onChainRelocations[relocation.nonce] = toOnChainRelocation(relocation);
+      }
+    });
+    expectedBridgeState.onChainRelocations[expectedBridgeState.onChainRelocations.length] = defaultOnChainRelocation;
+    expectedBridgeState.nonceCount = expectedBridgeState.onChainRelocations.length;
+
+    expectedBridgeState.pendingRelocationCount =
+      expectedBridgeState.requestedRelocationCount - expectedBridgeState.processedRelocationCount;
+
+    return expectedBridgeState;
+  }
+
+  function defineExpectedBridgeStatesPerChainId(
+    relocations: TestTokenRelocation[]
+  ): Map<number, BridgeStateForChainId> {
+    const expectedChainIds: Set<number> = defineExpectedChainIds(relocations);
+    const expectedStatesByChainId: Map<number, BridgeStateForChainId> = new Map<number, BridgeStateForChainId>();
+
+    expectedChainIds.forEach((chainId: number) => {
+      const expectedBridgeState: BridgeStateForChainId =
+        defineExpectedBridgeStateForSingleChainId(chainId, relocations);
+      expectedStatesByChainId.set(chainId, expectedBridgeState);
+    });
+
+    return expectedStatesByChainId;
+  }
+
+  function defineExpectedBridgeBalancesPerTokens(relocations: TestTokenRelocation[]): Map<Contract, number> {
+    const expectedTokens: Set<Contract> = defineExpectedTokens(relocations);
+    const expectedBridgeBalancesPerToken: Map<Contract, number> = new Map<Contract, number>();
+
+    expectedTokens.forEach((token: Contract) => {
+      const expectedBalance: number = countNumberArrayTotal(
+        relocations.map(
+          function (relocation: TestTokenRelocation): number {
+            if (relocation.token == token
+              && !!relocation.requested
+              && (operationMode === OperationMode.LockOrTransfer || !relocation.processed)
+              && !relocation.canceled
+            ) {
+              return relocation.amount;
+            } else {
+              return 0;
+            }
+          }
+        )
+      );
+      expectedBridgeBalancesPerToken.set(token, expectedBalance);
+    });
+    return expectedBridgeBalancesPerToken;
+  }
+
+  async function checkBridgeStatesPerChainId(expectedBridgeStatesByChainId: Map<number, BridgeStateForChainId>) {
+    for (const expectedChainId of expectedBridgeStatesByChainId.keys()) {
+      const expectedBridgeState: BridgeStateForChainId | undefined = expectedBridgeStatesByChainId.get(expectedChainId);
+      if (!expectedBridgeState) {
+        continue;
+      }
+      expect(
+        await multiTokenBridge.getPendingRelocationCounter(expectedChainId)
+      ).to.equal(
+        expectedBridgeState.pendingRelocationCount,
+        `Wrong pending relocation count, chainId=${expectedChainId}`
+      );
+      expect(
+        await multiTokenBridge.getLastProcessedRelocationNonce(expectedChainId)
+      ).to.equal(
+        expectedBridgeState.processedRelocationCount,
+        `Wrong requested relocation count, chainId=${expectedChainId}`
+      );
+      const actualRelocations = await multiTokenBridge.getRelocations(
+        expectedChainId,
+        expectedBridgeState.firstNonce,
+        expectedBridgeState.nonceCount
+      );
+      expect(actualRelocations.length).to.equal(expectedBridgeState.onChainRelocations.length);
+      for (let i = 0; i < expectedBridgeState.onChainRelocations.length; ++i) {
+        const onChainRelocation: OnChainRelocation = expectedBridgeState.onChainRelocations[i];
+        checkEquality(actualRelocations[i], onChainRelocation, i, expectedChainId);
+      }
+    }
+  }
+
+  async function checkRelocationStructures(relocations: TestTokenRelocation[]) {
+    for (let i = 0; i < relocations.length; ++i) {
+      const relocation = relocations[i];
+      if (relocation.requested) {
+        const actualRelocation = await multiTokenBridge.getRelocation(relocation.chainId, relocation.nonce);
+        checkEquality(actualRelocation, toOnChainRelocation(relocation), i, relocation.chainId);
+      }
+    }
+  }
+
+  async function checkBridgeBalancesPerToken(expectedBalancesPerToken: Map<Contract, number>) {
+    for (const expectedToken of expectedBalancesPerToken.keys()) {
+      const expectedBalance: number | undefined = expectedBalancesPerToken.get(expectedToken);
+      if (!expectedBalance) {
+        continue;
+      }
+      const tokenSymbol = await expectedToken.symbol();
+      expect(
+        await expectedToken.balanceOf(multiTokenBridge.address)
+      ).to.equal(
+        expectedBalance,
+        `Balance is wrong for token with symbol ${tokenSymbol}`
+      );
+    }
+  }
+
+  async function checkBridgeState(relocations: TestTokenRelocation[]): Promise<void> {
+    const expectedBridgeStatesByChainId: Map<number, BridgeStateForChainId> =
+      defineExpectedBridgeStatesPerChainId(relocations);
+    const expectedBridgeBalancesPerToken: Map<Contract, number> = defineExpectedBridgeBalancesPerTokens(relocations);
+
+    await checkBridgeStatesPerChainId(expectedBridgeStatesByChainId);
+    await checkRelocationStructures(relocations);
+    await checkBridgeBalancesPerToken(expectedBridgeBalancesPerToken);
+  }
+
+  beforeEach(async () => {
+    // Deploy TokenBridge
+    const MultiTokenBridge: ContractFactory = await ethers.getContractFactory("MultiTokenBridge");
+    multiTokenBridge = await MultiTokenBridge.deploy();
+    await multiTokenBridge.deployed();
+    await proveTx(multiTokenBridge.initialize());
+
+    // Get user accounts
+    [deployer, user1, user2] = await ethers.getSigners();
+
+    // Roles
+    ownerRole = (await multiTokenBridge.OWNER_ROLE()).toLowerCase();
+    pauserRole = (await multiTokenBridge.PAUSER_ROLE()).toLowerCase();
+    rescuerRole = (await multiTokenBridge.RESCUER_ROLE()).toLowerCase();
+    bridgerRole = (await multiTokenBridge.BRIDGER_ROLE()).toLowerCase();
+
+    fakeTokenAddress = user1.address;
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      multiTokenBridge.initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initial contract configuration should be as expected", async () => {
+    // The role admins
+    expect(await multiTokenBridge.getRoleAdmin(ownerRole)).to.equal(ownerRole);
+    expect(await multiTokenBridge.getRoleAdmin(pauserRole)).to.equal(ownerRole);
+    expect(await multiTokenBridge.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+    expect(await multiTokenBridge.getRoleAdmin(bridgerRole)).to.equal(ownerRole);
+
+    // The deployer should have the owner role, but not the other roles
+    expect(await multiTokenBridge.hasRole(ownerRole, deployer.address)).to.equal(true);
+    expect(await multiTokenBridge.hasRole(pauserRole, deployer.address)).to.equal(false);
+    expect(await multiTokenBridge.hasRole(rescuerRole, deployer.address)).to.equal(false);
+    expect(await multiTokenBridge.hasRole(bridgerRole, deployer.address)).to.equal(false);
+
+    // The initial contract state is unpaused
+    expect(await multiTokenBridge.paused()).to.equal(false);
+  });
+
+  describe("Configuration", async () => {
+    let tokenMock: Contract;
+
+    beforeEach(async () => {
+      operationMode = OperationMode.Unsupported;
+      tokenMock = await deployTokenMock(1);
+    });
+
+    describe("Function 'setRelocationMode()'", async () => {
+      const chainId = 123;
+
+      it("Is reverted if is called not by the account with the owner role", async () => {
+        await expect(
+          multiTokenBridge.connect(user1).setRelocationMode(
+            chainId,
+            tokenMock.address,
+            OperationMode.BurnOrMint
+          )
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
+      });
+
+      it("Is reverted if the new mode is BurnOrMint and the token does not support bridge operations", async () => {
+        await expect(
+          multiTokenBridge.setRelocationMode(
+            chainId,
+            fakeTokenAddress,
+            OperationMode.BurnOrMint
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_TOKEN_DOES_NOT_SUPPORT_BRIDGE_OPERATIONS);
+      });
+
+      it("Emits the correct events and updates the configuration correctly", async () => {
+        const relocationModeOld: OperationMode = await multiTokenBridge.getRelocationMode(chainId, tokenMock.address);
+        expect(relocationModeOld).to.equal(OperationMode.Unsupported);
+        await expect(
+          multiTokenBridge.setRelocationMode(
+            chainId,
+            tokenMock.address,
+            OperationMode.BurnOrMint
+          )
+        ).to.emit(
+          multiTokenBridge,
+          "SetRelocationMode"
+        ).withArgs(
+          chainId,
+          tokenMock.address,
+          OperationMode.Unsupported,
+          OperationMode.BurnOrMint
+        );
+        const relocationModeNew: OperationMode = await multiTokenBridge.getRelocationMode(chainId, tokenMock.address);
+        expect(relocationModeNew).to.equal(OperationMode.BurnOrMint);
+
+        // Second call with the same argument should not emit an event
+        await expect(
+          multiTokenBridge.setRelocationMode(
+            chainId,
+            tokenMock.address,
+            OperationMode.BurnOrMint
+          )
+        ).not.to.emit(multiTokenBridge, "SetRelocationMode");
+
+        await expect(
+          multiTokenBridge.setRelocationMode(
+            chainId,
+            tokenMock.address,
+            OperationMode.LockOrTransfer
+          )
+        ).to.emit(
+          multiTokenBridge,
+          "SetRelocationMode"
+        ).withArgs(
+          chainId,
+          tokenMock.address,
+          OperationMode.BurnOrMint,
+          OperationMode.LockOrTransfer
+        );
+        const relocationModeNew2: OperationMode = await multiTokenBridge.getRelocationMode(chainId, tokenMock.address);
+        expect(relocationModeNew2).to.equal(OperationMode.LockOrTransfer);
+
+        await expect(
+          multiTokenBridge.setRelocationMode(
+            chainId,
+            tokenMock.address,
+            OperationMode.Unsupported
+          )
+        ).to.emit(
+          multiTokenBridge,
+          "SetRelocationMode"
+        ).withArgs(
+          chainId,
+          tokenMock.address,
+          OperationMode.LockOrTransfer,
+          OperationMode.Unsupported
+        );
+        const relocationModeNew3: OperationMode = await multiTokenBridge.getRelocationMode(chainId, tokenMock.address);
+        expect(relocationModeNew3).to.equal(OperationMode.Unsupported);
+      });
+    });
+
+    describe("Function 'setAccommodationMode()'", async () => {
+      const chainId = 123;
+
+      it("Is reverted if is called not by the account with the owner role", async () => {
+        await expect(
+          multiTokenBridge.connect(user1).setAccommodationMode(
+            chainId,
+            tokenMock.address,
+            OperationMode.BurnOrMint
+          )
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
+      });
+
+      it("Is reverted if the new mode is BurnOrMint and the token does not support bridge operations", async () => {
+        await expect(
+          multiTokenBridge.setAccommodationMode(
+            chainId,
+            fakeTokenAddress,
+            OperationMode.BurnOrMint
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_TOKEN_DOES_NOT_SUPPORT_BRIDGE_OPERATIONS);
+      });
+
+      it("Emits the correct events and updates the configuration correctly", async () => {
+        const accommodationModeOld: OperationMode =
+          await multiTokenBridge.getAccommodationMode(chainId, tokenMock.address);
+        expect(accommodationModeOld).to.equal(OperationMode.Unsupported);
+        await expect(
+          multiTokenBridge.setAccommodationMode(
+            chainId,
+            tokenMock.address,
+            OperationMode.BurnOrMint
+          )
+        ).to.emit(
+          multiTokenBridge,
+          "SetAccommodationMode"
+        ).withArgs(
+          chainId,
+          tokenMock.address,
+          OperationMode.Unsupported,
+          OperationMode.BurnOrMint
+        );
+        const accommodationModeNew: OperationMode =
+          await multiTokenBridge.getAccommodationMode(chainId, tokenMock.address);
+        expect(accommodationModeNew).to.equal(OperationMode.BurnOrMint);
+
+        // Second call with the same argument should not emit an event
+        await expect(
+          multiTokenBridge.setAccommodationMode(
+            chainId,
+            tokenMock.address,
+            OperationMode.BurnOrMint
+          )
+        ).not.to.emit(multiTokenBridge, "SetAccommodationMode");
+
+        await expect(
+          multiTokenBridge.setAccommodationMode(
+            chainId,
+            tokenMock.address,
+            OperationMode.LockOrTransfer
+          )
+        ).to.emit(
+          multiTokenBridge,
+          "SetAccommodationMode"
+        ).withArgs(
+          chainId,
+          tokenMock.address,
+          OperationMode.BurnOrMint,
+          OperationMode.LockOrTransfer
+        );
+        const accommodationModeNew2: OperationMode =
+          await multiTokenBridge.getAccommodationMode(chainId, tokenMock.address);
+        expect(accommodationModeNew2).to.equal(OperationMode.LockOrTransfer);
+
+        await expect(
+          multiTokenBridge.setAccommodationMode(
+            chainId,
+            tokenMock.address,
+            OperationMode.Unsupported
+          )
+        ).to.emit(
+          multiTokenBridge,
+          "SetAccommodationMode"
+        ).withArgs(
+          chainId,
+          tokenMock.address,
+          OperationMode.LockOrTransfer,
+          OperationMode.Unsupported
+        );
+        const accommodationModeNew3: OperationMode =
+          await multiTokenBridge.getAccommodationMode(chainId, tokenMock.address);
+        expect(accommodationModeNew3).to.equal(OperationMode.Unsupported);
+      });
+    });
+  });
+
+  describe("Interactions related to relocations in the BurnOrMint operation mode", async () => {
+    let tokenMock1: Contract;
+
+    beforeEach(async () => {
+      operationMode = OperationMode.BurnOrMint;
+      tokenMock1 = await deployTokenMock(1);
+    });
+
+    describe("Function 'requestRelocation()'", async () => {
+      let relocation: TestTokenRelocation;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 123,
+          token: tokenMock1,
+          account: user1,
+          amount: 456,
+          nonce: 1,
+        };
+        await setUpContractsForRelocations([relocation]);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseMultiTokenBridge();
+        await expect(
+          multiTokenBridge.connect(relocation.account).requestRelocation(
+            relocation.chainId,
+            relocation.token.address,
+            relocation.amount
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the token address is zero", async () => {
+        await expect(
+          multiTokenBridge.connect(relocation.account).requestRelocation(
+            relocation.chainId,
+            ethers.constants.AddressZero,
+            relocation.amount
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_RELOCATION_TOKEN_ADDRESS_IS_ZERO);
+      });
+
+      it("Is reverted if the token amount of the relocation is zero", async () => {
+        await expect(
+          multiTokenBridge.connect(relocation.account).requestRelocation(
+            relocation.chainId,
+            relocation.token.address,
+            0
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_RELOCATION_AMOUNT_IS_ZERO);
+      });
+
+      it("Is reverted if the target chain is unsupported for relocations", async () => {
+        await expect(
+          multiTokenBridge.connect(relocation.account).requestRelocation(
+            relocation.chainId + 1,
+            relocation.token.address,
+            relocation.amount
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_RELOCATION_IS_UNSUPPORTED);
+      });
+
+      it("Is reverted if the token is unsupported for relocations", async () => {
+        await expect(
+          multiTokenBridge.connect(relocation.account).requestRelocation(
+            relocation.chainId,
+            fakeTokenAddress,
+            relocation.amount
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_RELOCATION_IS_UNSUPPORTED);
+      });
+
+      it("Is reverted if the token does not support the bridge", async () => {
+        await proveTx(tokenMock1.setBridge(deployer.address));
+        await expect(
+          multiTokenBridge.connect(relocation.account).requestRelocation(
+            relocation.chainId,
+            relocation.token.address,
+            relocation.amount
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_UNSUPPORTING_TOKEN);
+      });
+
+      it("Is reverted if the user has not enough token balance", async () => {
+        const excessTokenAmount: number = relocation.amount + 1;
+        await expect(
+          multiTokenBridge.connect(relocation.account).requestRelocation(
+            relocation.chainId,
+            relocation.token.address,
+            excessTokenAmount
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+      });
+
+      it("Transfers tokens as expected, emits the correct event, changes the state properly", async () => {
+        await checkBridgeState([relocation]);
+        await expect(
+          multiTokenBridge.connect(relocation.account).requestRelocation(
+            relocation.chainId,
+            relocation.token.address,
+            relocation.amount
+          )
+        ).to.changeTokenBalances(
+          relocation.token,
+          [multiTokenBridge, relocation.account],
+          [+relocation.amount, -relocation.amount,]
+        ).and.to.emit(
+          multiTokenBridge,
+          "RequestRelocation"
+        ).withArgs(
+          relocation.chainId,
+          relocation.token.address,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce
+        );
+        relocation.requested = true;
+        await checkBridgeState([relocation]);
+      });
+    });
+
+    describe("Function 'cancelRelocation()'", async () => {
+      let relocation: TestTokenRelocation;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 234,
+          token: tokenMock1,
+          account: user1,
+          amount: 567,
+          nonce: 1,
+        };
+        await setUpContractsForRelocations([relocation]);
+        await requestRelocations([relocation]);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseMultiTokenBridge();
+        await expect(
+          multiTokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller did not request the relocation", async () => {
+        await expect(
+          multiTokenBridge.connect(user2).cancelRelocation(relocation.chainId, relocation.nonce)
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_TRANSACTION_SENDER_IS_UNAUTHORIZED);
+      });
+
+      it("Is reverted if a relocation with the nonce has already processed", async () => {
+        await expect(
+          multiTokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce - 1)
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_TRANSACTION_SENDER_IS_UNAUTHORIZED);
+      });
+
+      it("Is reverted if a relocation with the nonce does not exists", async () => {
+        await expect(
+          multiTokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce + 1)
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_TRANSACTION_SENDER_IS_UNAUTHORIZED);
+      });
+
+      it("Transfers the tokens as expected, emits the correct event, changes the state properly", async () => {
+        await checkBridgeState([relocation]);
+        await expect(
+          multiTokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce)
+        ).to.changeTokenBalances(
+          tokenMock1,
+          [multiTokenBridge, relocation.account],
+          [-relocation.amount, +relocation.amount]
+        ).and.to.emit(
+          multiTokenBridge,
+          "CancelRelocation"
+        ).withArgs(
+          relocation.chainId,
+          relocation.token.address,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce
+        );
+        relocation.canceled = true;
+        await checkBridgeState([relocation]);
+      });
+    });
+
+    describe("Function 'cancelRelocations()'", async () => {
+      const chainId = 12;
+
+      let tokenMock2: Contract;
+      let relocations: TestTokenRelocation[];
+      let relocator: SignerWithAddress;
+      let relocationNonces: number[];
+
+      beforeEach(async () => {
+        tokenMock2 = await deployTokenMock(2);
+
+        relocations = [
+          {
+            chainId: chainId,
+            token: tokenMock1,
+            account: user1,
+            amount: 34,
+            nonce: 1,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock2,
+            account: user2,
+            amount: 56,
+            nonce: 2,
+          },
+        ];
+        relocationNonces = relocations.map((relocation: TestTokenRelocation) => relocation.nonce);
+        relocator = user2;
+        await setUpContractsForRelocations(relocations);
+        await requestRelocations(relocations);
+        await setBridgerRole(relocator);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseMultiTokenBridge();
+        await expect(
+          multiTokenBridge.connect(relocator).cancelRelocations(chainId, relocationNonces)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller does not have the bridger role", async () => {
+        await expect(
+          multiTokenBridge.connect(deployer).cancelRelocations(chainId, relocationNonces)
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, bridgerRole));
+      });
+
+      it("Is reverted if the input array of nonces is empty", async () => {
+        await expect(
+          multiTokenBridge.connect(relocator).cancelRelocations(chainId, [])
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_RELOCATION_ARRAY_OF_NONCES_IS_EMPTY);
+      });
+
+      it("Is reverted if some input nonce is less than the lowest nonce of pending relocations", async () => {
+        await expect(multiTokenBridge.connect(relocator).cancelRelocations(
+          chainId,
+          [
+            Math.min(...relocationNonces),
+            Math.min(...relocationNonces) - 1,
+          ]
+        )).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_RELOCATION_IS_ALREADY_PROCESSED);
+      });
+
+      it("Is reverted if some input nonce is greater than the highest nonce of pending relocations", async () => {
+        await expect(multiTokenBridge.connect(relocator).cancelRelocations(
+          chainId,
+          [
+            Math.max(...relocationNonces),
+            Math.max(...relocationNonces) + 1
+          ]
+        )).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_RELOCATION_DOES_NOT_EXIST);
+      });
+
+      it("Is reverted if a relocation with some nonce was already canceled", async () => {
+        await cancelRelocations([relocations[1]]);
+        await expect(
+          multiTokenBridge.connect(relocator).cancelRelocations(chainId, relocationNonces)
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_RELOCATION_IS_ALREADY_CANCELED);
+      });
+
+      it("Transfers the tokens as expected, emits the correct events, changes the state properly", async () => {
+        await checkBridgeState(relocations);
+        const relocationAccountAddresses: string[] =
+          relocations.map((relocation: TestTokenRelocation) => relocation.account.address);
+        const expectedAccountBalanceChangesForTokenMock1: number[] = getAmountByTokenAndAddresses(
+          relocations,
+          tokenMock1,
+          relocationAccountAddresses
+        );
+        const expectedAccountBalanceChangesForTokenMock2: number[] = getAmountByTokenAndAddresses(
+          relocations,
+          tokenMock2,
+          relocationAccountAddresses
+        );
+        const expectedBridgeBalanceChangeForTokenMock1 =
+          countNumberArrayTotal(expectedAccountBalanceChangesForTokenMock1);
+        const expectedBridgeBalanceChangeForTokenMock2 =
+          countNumberArrayTotal(expectedAccountBalanceChangesForTokenMock2);
+
+        await expect(
+          multiTokenBridge.connect(relocator).cancelRelocations(chainId, relocationNonces)
+        ).to.changeTokenBalances(
+          tokenMock1,
+          [multiTokenBridge, ...relocationAccountAddresses],
+          [-expectedBridgeBalanceChangeForTokenMock1, ...expectedAccountBalanceChangesForTokenMock1]
+        ).and.to.changeTokenBalances(
+          tokenMock2,
+          [multiTokenBridge, ...relocationAccountAddresses],
+          [-expectedBridgeBalanceChangeForTokenMock2, ...expectedAccountBalanceChangesForTokenMock2]
+        ).and.to.emit(
+          multiTokenBridge,
+          "CancelRelocation"
+        ).withArgs(
+          chainId,
+          relocations[0].token.address,
+          relocations[0].account.address,
+          relocations[0].amount,
+          relocations[0].nonce
+        ).and.to.emit(
+          multiTokenBridge,
+          "CancelRelocation"
+        ).withArgs(
+          chainId,
+          relocations[1].token.address,
+          relocations[1].account.address,
+          relocations[1].amount,
+          relocations[1].nonce
+        );
+        relocations.forEach((relocation: TestTokenRelocation) => relocation.canceled = true);
+        await checkBridgeState(relocations);
+      });
+    });
+
+    describe("Function 'relocate()'", async () => {
+      const relocationCount = 1;
+
+      let relocation: TestTokenRelocation;
+      let relocator: SignerWithAddress;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 345,
+          token: tokenMock1,
+          account: user1,
+          amount: 678,
+          nonce: 1,
+        };
+        relocator = user2;
+
+        await setUpContractsForRelocations([relocation]);
+        await requestRelocations([relocation]);
+        await setBridgerRole(relocator);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseMultiTokenBridge();
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller does not have the bridger role", async () => {
+        await expect(
+          multiTokenBridge.connect(deployer).relocate(relocation.chainId, relocationCount)
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, bridgerRole));
+      });
+
+      it("Is reverted if the relocation count is zero", async () => {
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, 0)
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_RELOCATION_COUNT_IS_ZERO);
+      });
+
+      it("Is reverted if the relocation count exceeds the number of pending relocations", async () => {
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount + 1)
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_THERE_IS_LACK_PENDING_RELOCATIONS);
+      });
+
+      it("Is reverted if the token does not support the bridge", async () => {
+        await proveTx(tokenMock1.setBridge(deployer.address));
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_UNSUPPORTING_TOKEN);
+      });
+
+      it("Is reverted if burning of tokens had failed", async () => {
+        await proveTx(tokenMock1.disableBurningForBridging());
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_BURNING_OF_TOKENS_FAILED);
+      });
+
+      it("Burns no tokens, emits no events if the relocation was canceled", async () => {
+        await cancelRelocations([relocation]);
+        await checkBridgeState([relocation]);
+        const balanceBefore: BigNumber = await tokenMock1.balanceOf(multiTokenBridge.address);
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).and.not.to.emit(
+          multiTokenBridge,
+          "Relocate"
+        );
+        const balanceAfter: BigNumber = await tokenMock1.balanceOf(multiTokenBridge.address);
+        expect(balanceAfter.sub(balanceBefore)).to.equal(0);
+        markRelocationsAsProcessed([relocation]);
+        await checkBridgeState([relocation]);
+      });
+
+      it("Burns tokens as expected, emits the correct event, changes the state properly", async () => {
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.changeTokenBalances(
+          tokenMock1,
+          [multiTokenBridge, user1, user2],
+          [-relocation.amount, 0, 0]
+        ).and.to.emit(
+          multiTokenBridge,
+          "Relocate"
+        ).withArgs(
+          relocation.chainId,
+          relocation.token.address,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce,
+          operationMode
+        );
+        markRelocationsAsProcessed([relocation]);
+        await checkBridgeState([relocation]);
+      });
+    });
+
+    describe("Complex scenario for a single chain with several tokens", async () => {
+      const chainId = 123;
+
+      let tokenMock2: Contract;
+      let relocations: TestTokenRelocation[];
+      let relocator: SignerWithAddress;
+
+      beforeEach(async () => {
+        tokenMock2 = await deployTokenMock(2);
+
+        relocations = [
+          {
+            chainId: chainId,
+            token: tokenMock1,
+            account: user1,
+            amount: 234,
+            nonce: 1,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock2,
+            account: user1,
+            amount: 345,
+            nonce: 2,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock2,
+            account: user2,
+            amount: 456,
+            nonce: 3,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock1,
+            account: deployer,
+            amount: 567,
+            nonce: 4,
+          },
+        ];
+        relocator = user2;
+        await setUpContractsForRelocations(relocations);
+        await setBridgerRole(relocator);
+      });
+
+      it("Executes as expected", async () => {
+        // Request first 3 relocations
+        await requestRelocations([relocations[0], relocations[1], relocations[2]]);
+        await checkBridgeState(relocations);
+
+        // Process the first relocation
+        await proveTx(multiTokenBridge.connect(relocator).relocate(chainId, 1));
+        markRelocationsAsProcessed([relocations[0]]);
+        await checkBridgeState(relocations);
+
+        // Try to cancel already processed relocation
+        await expect(
+          multiTokenBridge.connect(relocations[0].account).cancelRelocation(chainId, relocations[0].nonce)
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_RELOCATION_IS_ALREADY_PROCESSED);
+
+        // Try to cancel a relocation of another user
+        await expect(
+          multiTokenBridge.connect(relocations[1].account).cancelRelocation(chainId, relocations[2].nonce)
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_TRANSACTION_SENDER_IS_UNAUTHORIZED);
+
+        // Try to cancel several relocations including the processed one
+        await expect(
+          multiTokenBridge.connect(relocator).cancelRelocations(chainId, [
+            relocations[2].nonce,
+            relocations[1].nonce,
+            relocations[0].nonce,
+          ])
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_RELOCATION_IS_ALREADY_PROCESSED);
+
+        // Try to cancel several relocations including one that is out of the pending range
+        await expect(
+          multiTokenBridge.connect(relocator).cancelRelocations(chainId, [
+            relocations[3].nonce,
+            relocations[2].nonce,
+            relocations[1].nonce,
+          ])
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_RELOCATION_DOES_NOT_EXIST);
+
+        // Check that state of the bridge has not changed
+        await checkBridgeState(relocations);
+
+        // Request another relocation
+        await requestRelocations([relocations[3]]);
+        await checkBridgeState(relocations);
+
+        // Cancel two last relocations
+        await proveTx(
+          multiTokenBridge.connect(relocator).cancelRelocations(
+            chainId,
+            [relocations[3].nonce, relocations[2].nonce]
+          )
+        );
+        [relocations[3], relocations[2]].forEach((relocation: TestTokenRelocation) => relocation.canceled = true);
+        await checkBridgeState(relocations);
+
+        // Process all the pending relocations
+        await proveTx(multiTokenBridge.connect(relocator).relocate(chainId, 3));
+        markRelocationsAsProcessed(relocations);
+        await checkBridgeState(relocations);
+      });
+    });
+
+    describe("Complex scenario for several chains with several tokens", async () => {
+      const chainId1 = 123;
+      const chainId2 = 234;
+
+      let tokenMock2: Contract;
+      let relocations: TestTokenRelocation[];
+      let relocator: SignerWithAddress;
+      let relocationCountForChain1: number;
+      let relocationCountForChain2: number;
+
+      beforeEach(async () => {
+        tokenMock2 = await deployTokenMock(2);
+
+        relocations = [
+          {
+            chainId: chainId1,
+            token: tokenMock2,
+            account: user1,
+            amount: 345,
+            nonce: 1,
+          },
+          {
+            chainId: chainId1,
+            token: tokenMock1,
+            account: user1,
+            amount: 456,
+            nonce: 2,
+          },
+          {
+            chainId: chainId2,
+            token: tokenMock1,
+            account: user2,
+            amount: 567,
+            nonce: 1,
+          },
+          {
+            chainId: chainId2,
+            token: tokenMock2,
+            account: deployer,
+            amount: 678,
+            nonce: 2,
+          },
+        ];
+        relocator = user2;
+        relocationCountForChain1 = countRelocationsForChainId(relocations, chainId1);
+        relocationCountForChain2 = countRelocationsForChainId(relocations, chainId2);
+        await setUpContractsForRelocations(relocations);
+        await setBridgerRole(relocator);
+      });
+
+      it("Executes as expected", async () => {
+        // Request all relocations
+        await requestRelocations(relocations);
+        await checkBridgeState(relocations);
+
+        // Cancel some relocations
+        await cancelRelocations([relocations[1], relocations[2]]);
+        await checkBridgeState(relocations);
+
+        // Process all the pending relocations in all the chains
+        await proveTx(multiTokenBridge.connect(relocator).relocate(chainId1, relocationCountForChain1));
+        await proveTx(multiTokenBridge.connect(relocator).relocate(chainId2, relocationCountForChain2));
+        markRelocationsAsProcessed(relocations);
+        await checkBridgeState(relocations);
+      });
+    });
+  });
+
+  describe("Interactions related to relocations in the LockOrTransfer operation mode", async () => {
+    let tokenMock: Contract;
+
+    beforeEach(async () => {
+      operationMode = OperationMode.LockOrTransfer;
+      tokenMock = await deployTokenMock(1);
+    });
+
+    describe("Function 'requestRelocation()'", async () => {
+      let relocation: TestTokenRelocation;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 123,
+          token: tokenMock,
+          account: user1,
+          amount: 456,
+          nonce: 1,
+        };
+        await setUpContractsForRelocations([relocation]);
+      });
+
+      it("Transfers tokens as expected, emits the correct event, changes the state properly", async () => {
+        await checkBridgeState([relocation]);
+        await expect(
+          multiTokenBridge.connect(relocation.account).requestRelocation(
+            relocation.chainId,
+            relocation.token.address,
+            relocation.amount
+          )
+        ).to.changeTokenBalances(
+          relocation.token,
+          [multiTokenBridge, relocation.account],
+          [+relocation.amount, -relocation.amount,]
+        ).and.to.emit(
+          multiTokenBridge,
+          "RequestRelocation"
+        ).withArgs(
+          relocation.chainId,
+          relocation.token.address,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce
+        );
+        relocation.requested = true;
+        await checkBridgeState([relocation]);
+      });
+    });
+
+    describe("Function 'relocate()'", async () => {
+      const relocationCount = 1;
+
+      let relocation: TestTokenRelocation;
+      let relocator: SignerWithAddress;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 345,
+          token: tokenMock,
+          account: user1,
+          amount: 678,
+          nonce: 1,
+        };
+        relocator = user2;
+
+        await setUpContractsForRelocations([relocation]);
+        await requestRelocations([relocation]);
+        await setBridgerRole(relocator);
+      });
+
+      it("Burns no tokens, emits the correct event, changes the state properly", async () => {
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.changeTokenBalances(
+          relocation.token,
+          [multiTokenBridge, relocation.account],
+          [0, 0]
+        ).and.to.emit(
+          multiTokenBridge,
+          "Relocate"
+        ).withArgs(
+          relocation.chainId,
+          relocation.token.address,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce,
+          OperationMode.LockOrTransfer
+        );
+        markRelocationsAsProcessed([relocation]);
+        await checkBridgeState([relocation]);
+      });
+    });
+  });
+
+  describe("Interactions related to accommodations in the BurnOrMint operation mode", async () => {
+
+    describe("Function 'accommodate()'", async () => {
+      const chainId = 123;
+      const firstRelocationNonce = 1;
+
+      let tokenMock1: Contract;
+      let tokenMock2: Contract;
+      let relocations: TestTokenRelocation[];
+      let accommodator: SignerWithAddress;
+      let onChainRelocations: OnChainRelocation[];
+
+      beforeEach(async () => {
+        operationMode = OperationMode.BurnOrMint;
+        tokenMock1 = await deployTokenMock(1);
+        tokenMock2 = await deployTokenMock(2);
+
+        relocations = [
+          {
+            chainId: chainId,
+            token: tokenMock1,
+            account: user1,
+            amount: 456,
+            nonce: firstRelocationNonce,
+            canceled: true,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock1,
+            account: user2,
+            amount: 567,
+            nonce: firstRelocationNonce + 1,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock2,
+            account: user2,
+            amount: 678,
+            nonce: firstRelocationNonce + 2,
+          },
+        ];
+        accommodator = user2;
+        onChainRelocations = relocations.map(toOnChainRelocation);
+
+        await proveTx(
+          multiTokenBridge.setAccommodationMode(
+            chainId,
+            tokenMock1.address,
+            operationMode
+          )
+        );
+        await proveTx(
+          multiTokenBridge.setAccommodationMode(
+            chainId,
+            tokenMock2.address,
+            operationMode
+          )
+        );
+        await setBridgerRole(accommodator);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseMultiTokenBridge();
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller does not have the bridger role", async () => {
+        await expect(
+          multiTokenBridge.connect(deployer).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, bridgerRole));
+      });
+
+      it("Is reverted if the chain is unsupported for accommodations", async () => {
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId + 1,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_ACCOMMODATION_IS_UNSUPPORTED);
+      });
+
+      it("Is reverted if one of the token contracts is unsupported for accommodations", async () => {
+        onChainRelocations[1].token = deployer.address;
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_ACCOMMODATION_IS_UNSUPPORTED);
+      });
+
+      it("Is reverted if the first relocation nonce is zero", async () => {
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            0,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_ACCOMMODATION_FIRST_NONCE_IS_ZERO);
+      });
+
+      it("Is reverted if the first relocation nonce does not equal the last accommodation nonce +1", async () => {
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce + 1,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_ACCOMMODATION_NONCE_MISMATCH);
+      });
+
+      it("Is reverted if the input array of relocations is empty", async () => {
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            []
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_INPUT_ARRAY_OF_RELOCATIONS_IS_EMPTY);
+      });
+
+      it("Is reverted if one of the tokens does not support the bridge", async () => {
+        await proveTx(tokenMock1.setBridge(deployer.address));
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_UNSUPPORTING_TOKEN);
+      });
+
+      it("Is reverted if one of the input accounts has zero address", async () => {
+        onChainRelocations[1].account = ethers.constants.AddressZero;
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_ACCOMMODATION_ACCOUNT_IS_ZERO_ADDRESS);
+      });
+
+      it("Is reverted if one of the input amounts is zero", async () => {
+        onChainRelocations[1].amount = ethers.constants.Zero;
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_ACCOMMODATION_AMOUNT_IS_ZERO);
+      });
+
+      it("Is reverted if minting of tokens had failed", async () => {
+        await proveTx(tokenMock1.disableMintingForBridging());
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(multiTokenBridge, REVERT_ERROR_IF_MINTING_OF_TOKENS_FAILED);
+      });
+
+      it("Mints tokens as expected, emits the correct events, changes the state properly", async () => {
+        const relocationAccountAddresses: string[] =
+          relocations.map((relocation: TestTokenRelocation) => relocation.account.address);
+        const relocationAccountAddressesWithoutDuplicates: string[] = [...new Set(relocationAccountAddresses)];
+        const expectedBalanceChangesForTokenMock1: number[] = getAmountByTokenAndAddresses(
+          relocations,
+          tokenMock1,
+          relocationAccountAddressesWithoutDuplicates
+        );
+        const expectedBalanceChangesForTokenMock2: number[] = getAmountByTokenAndAddresses(
+          relocations,
+          tokenMock2,
+          relocationAccountAddressesWithoutDuplicates
+        );
+
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.changeTokenBalances(
+          tokenMock1,
+          [multiTokenBridge, ...relocationAccountAddressesWithoutDuplicates],
+          [0, ...expectedBalanceChangesForTokenMock1]
+        ).and.to.changeTokenBalances(
+          tokenMock2,
+          [multiTokenBridge, ...relocationAccountAddressesWithoutDuplicates],
+          [0, ...expectedBalanceChangesForTokenMock2]
+        ).and.to.emit(
+          multiTokenBridge,
+          "Accommodate"
+        ).withArgs(
+          chainId,
+          relocations[1].token.address,
+          relocations[1].account.address,
+          relocations[1].amount,
+          relocations[1].nonce,
+          operationMode
+        ).and.to.emit(
+          multiTokenBridge,
+          "Accommodate"
+        ).withArgs(
+          chainId,
+          relocations[2].token.address,
+          relocations[2].account.address,
+          relocations[2].amount,
+          relocations[2].nonce,
+          operationMode
+        );
+        expect(
+          await multiTokenBridge.getLastAccommodationNonce(chainId)
+        ).to.equal(relocations[relocations.length - 1].nonce);
+      });
+    });
+  });
+
+  describe("Interactions related to accommodations in the LockOrTransfer operation mode", async () => {
+
+    describe("Function 'accommodate()'", async () => {
+      const chainId = 123;
+      const firstRelocationNonce = 1;
+
+      let tokenMock1: Contract;
+      let tokenMock2: Contract;
+      let relocations: TestTokenRelocation[];
+      let accommodator: SignerWithAddress;
+      let onChainRelocations: OnChainRelocation[];
+
+      beforeEach(async () => {
+        operationMode = OperationMode.LockOrTransfer;
+        tokenMock1 = await deployTokenMock(1);
+        tokenMock2 = await deployTokenMock(2);
+
+        relocations = [
+          {
+            chainId: chainId,
+            token: tokenMock1,
+            account: user1,
+            amount: 456,
+            nonce: firstRelocationNonce,
+            canceled: true,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock1,
+            account: user2,
+            amount: 567,
+            nonce: firstRelocationNonce + 1,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock2,
+            account: user2,
+            amount: 678,
+            nonce: firstRelocationNonce + 2,
+          },
+        ];
+        accommodator = user2;
+        onChainRelocations = relocations.map(toOnChainRelocation);
+
+        await proveTx(
+          multiTokenBridge.setAccommodationMode(
+            chainId,
+            tokenMock1.address,
+            operationMode
+          )
+        );
+        await proveTx(
+          multiTokenBridge.setAccommodationMode(
+            chainId,
+            tokenMock2.address,
+            operationMode
+          )
+        );
+        await setBridgerRole(accommodator);
+      });
+
+      it("Transfers tokens as expected, emits the correct events, changes the state properly", async () => {
+        const relocationAccountAddresses: string[] =
+          relocations.map((relocation: TestTokenRelocation) => relocation.account.address);
+        const relocationAccountAddressesWithoutDuplicates: string[] = [...new Set(relocationAccountAddresses)];
+        const expectedBalanceChangesForTokenMock1: number[] = getAmountByTokenAndAddresses(
+          relocations,
+          tokenMock1,
+          relocationAccountAddressesWithoutDuplicates
+        );
+        const expectedBridgeBalanceChangeForTokenMock1: number =
+          countNumberArrayTotal(expectedBalanceChangesForTokenMock1);
+        const expectedBalanceChangesForTokenMock2: number[] = getAmountByTokenAndAddresses(
+          relocations,
+          tokenMock2,
+          relocationAccountAddressesWithoutDuplicates
+        );
+        const expectedBridgeBalanceChangeForTokenMock2: number =
+          countNumberArrayTotal(expectedBalanceChangesForTokenMock2);
+
+        await proveTx(tokenMock1.mint(multiTokenBridge.address, expectedBridgeBalanceChangeForTokenMock1));
+        await proveTx(tokenMock2.mint(multiTokenBridge.address, expectedBridgeBalanceChangeForTokenMock2));
+
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.changeTokenBalances(
+          tokenMock1,
+          [multiTokenBridge, ...relocationAccountAddressesWithoutDuplicates],
+          [-expectedBridgeBalanceChangeForTokenMock1, ...expectedBalanceChangesForTokenMock1]
+        ).and.to.changeTokenBalances(
+          tokenMock2,
+          [multiTokenBridge, ...relocationAccountAddressesWithoutDuplicates],
+          [-expectedBridgeBalanceChangeForTokenMock2, ...expectedBalanceChangesForTokenMock2]
+        ).and.to.emit(
+          multiTokenBridge,
+          "Accommodate"
+        ).withArgs(
+          chainId,
+          relocations[1].token.address,
+          relocations[1].account.address,
+          relocations[1].amount,
+          relocations[1].nonce,
+          operationMode
+        ).and.to.emit(
+          multiTokenBridge,
+          "Accommodate"
+        ).withArgs(
+          chainId,
+          relocations[2].token.address,
+          relocations[2].account.address,
+          relocations[2].amount,
+          relocations[2].nonce,
+          operationMode
+        );
+        expect(
+          await multiTokenBridge.getLastAccommodationNonce(chainId)
+        ).to.equal(relocations[relocations.length - 1].nonce);
+      });
+    });
+  });
+});

--- a/test/TokenBridge.test.ts
+++ b/test/TokenBridge.test.ts
@@ -1,0 +1,1333 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../test-utils/eth";
+import { countNumberArrayTotal, createRevertMessageDueToMissingRole } from "../test-utils/misc";
+
+enum OperationMode {
+  Unsupported = 0,
+  BurnOrMint = 1,
+  LockOrTransfer = 2,
+}
+
+interface TestTokenRelocation {
+  chainId: number;
+  account: SignerWithAddress;
+  amount: number;
+  nonce: number;
+  requested?: boolean;
+  processed?: boolean;
+  canceled?: boolean;
+}
+
+
+interface OnChainRelocation {
+  account: string;
+  amount: BigNumber;
+  canceled: boolean;
+}
+
+const defaultOnChainRelocation: OnChainRelocation = {
+  account: ethers.constants.AddressZero,
+  amount: ethers.constants.Zero,
+  canceled: false,
+};
+
+interface BridgeStateForChainId {
+  requestedRelocationCount: number;
+  processedRelocationCount: number;
+  pendingRelocationCount: number;
+  firstNonce: number;
+  nonceCount: number;
+  onChainRelocations: OnChainRelocation[];
+}
+
+function toOnChainRelocation(relocation: TestTokenRelocation): OnChainRelocation {
+  return {
+    account: relocation.account.address,
+    amount: BigNumber.from(relocation.amount),
+    canceled: relocation.canceled || false,
+  };
+}
+
+function checkEquality(
+  actualOnChainRelocation: any,
+  expectedRelocation: OnChainRelocation,
+  relocationIndex: number,
+  chainId: number
+) {
+  expect(actualOnChainRelocation.account).to.equal(
+    expectedRelocation.account,
+    `relocation[${relocationIndex}].account is incorrect, chainId=${chainId}`
+  );
+  expect(actualOnChainRelocation.amount).to.equal(
+    expectedRelocation.amount,
+    `relocation[${relocationIndex}].amount is incorrect, chainId=${chainId}`
+  );
+  expect(actualOnChainRelocation.canceled).to.equal(
+    expectedRelocation.canceled,
+    `relocation[${relocationIndex}].canceled is incorrect, chainId=${chainId}`
+  );
+}
+
+function countRelocationsForChainId(relocations: TestTokenRelocation[], targetChainId: number) {
+  return countNumberArrayTotal(
+    relocations.map(
+      function (relocation: TestTokenRelocation): number {
+        return (relocation.chainId == targetChainId) ? 1 : 0;
+      }
+    )
+  );
+}
+
+function markRelocationsAsProcessed(relocations: TestTokenRelocation[]) {
+  relocations.forEach((relocation: TestTokenRelocation) => relocation.processed = true);
+}
+
+describe("Contract 'TokenBridge'", async () => {
+  // Revert messages
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
+
+  const REVERT_ERROR_IF_TOKEN_DOES_NOT_SUPPORT_BRIDGE_OPERATIONS = "NonBridgeableToken";
+  const REVERT_ERROR_IF_RELOCATION_AMOUNT_IS_ZERO = "ZeroRelocationAmount";
+  const REVERT_ERROR_IF_RELOCATION_IS_UNSUPPORTED = "UnsupportedRelocation";
+  const REVERT_ERROR_IF_UNSUPPORTING_TOKEN = "UnsupportingToken";
+  const REVERT_ERROR_IF_TRANSACTION_SENDER_IS_UNAUTHORIZED = "UnauthorizedTransactionSender";
+  const REVERT_ERROR_IF_RELOCATION_ARRAY_OF_NONCES_IS_EMPTY = "EmptyNonceArray";
+  const REVERT_ERROR_IF_RELOCATION_IS_ALREADY_PROCESSED = "AlreadyProcessedRelocation";
+  const REVERT_ERROR_IF_RELOCATION_DOES_NOT_EXIST = "NotExistentRelocation";
+  const REVERT_ERROR_IF_RELOCATION_IS_ALREADY_CANCELED = "AlreadyCanceledRelocation";
+  const REVERT_ERROR_IF_RELOCATION_COUNT_IS_ZERO = "ZeroRelocationCount";
+  const REVERT_ERROR_IF_THERE_IS_LACK_PENDING_RELOCATIONS = "LackOfPendingRelocations";
+  const REVERT_ERROR_IF_BURNING_OF_TOKENS_FAILED = "TokenBurningFailure";
+  const REVERT_ERROR_IF_ACCOMMODATION_IS_UNSUPPORTED = "UnsupportedAccommodation";
+  const REVERT_ERROR_IF_ACCOMMODATION_FIRST_NONCE_IS_ZERO = "ZeroAccommodationNonce";
+  const REVERT_ERROR_IF_ACCOMMODATION_NONCE_MISMATCH = "AccommodationNonceMismatch";
+  const REVERT_ERROR_IF_INPUT_ARRAY_OF_RELOCATIONS_IS_EMPTY = "EmptyRelocationArray";
+  const REVERT_ERROR_IF_ACCOMMODATION_ACCOUNT_IS_ZERO_ADDRESS = "ZeroAccommodationAccount";
+  const REVERT_ERROR_IF_ACCOMMODATION_AMOUNT_IS_ZERO = "ZeroAccommodationAmount";
+  const REVERT_ERROR_IF_MINTING_OF_TOKENS_FAILED = "TokenMintingFailure";
+
+  let TokenBridge: ContractFactory;
+  let tokenBridge: Contract;
+  let tokenMock: Contract;
+  let deployer: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+  let ownerRole: string;
+  let pauserRole: string;
+  let rescuerRole: string;
+  let bridgerRole: string;
+  let operationMode: OperationMode;
+
+  async function setUpContractsForRelocations(relocations: TestTokenRelocation[]) {
+    for (const relocation of relocations) {
+      const relocationMode: OperationMode = await tokenBridge.getRelocationMode(relocation.chainId);
+      if (relocationMode !== operationMode) {
+        await proveTx(tokenBridge.setRelocationMode(relocation.chainId, operationMode));
+      }
+      await proveTx(tokenMock.mint(relocation.account.address, relocation.amount));
+      const allowance: BigNumber =
+        await tokenMock.allowance(relocation.account.address, tokenBridge.address);
+      if (allowance.lt(BigNumber.from(ethers.constants.MaxUint256))) {
+        await proveTx(
+          tokenMock.connect(relocation.account).approve(
+            tokenBridge.address,
+            ethers.constants.MaxUint256
+          )
+        );
+      }
+    }
+  }
+
+  async function requestRelocations(relocations: TestTokenRelocation[]) {
+    for (const relocation of relocations) {
+      await proveTx(
+        tokenBridge.connect(relocation.account).requestRelocation(relocation.chainId, relocation.amount)
+      );
+      relocation.requested = true;
+    }
+  }
+
+  async function pauseTokenBridge() {
+    await proveTx(tokenBridge.grantRole(pauserRole, deployer.address));
+    await proveTx(tokenBridge.pause());
+  }
+
+  async function setBridgerRole(account: SignerWithAddress) {
+    await proveTx(tokenBridge.grantRole(bridgerRole, account.address));
+  }
+
+  async function cancelRelocations(relocations: TestTokenRelocation[]) {
+    for (const relocation of relocations) {
+      await proveTx(
+        tokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce)
+      );
+      relocation.canceled = true;
+    }
+  }
+
+  function defineExpectedChainIds(relocations: TestTokenRelocation[]): Set<number> {
+    const expectedChainIds: Set<number> = new Set<number>();
+
+    relocations.forEach((relocation: TestTokenRelocation) => {
+      expectedChainIds.add(relocation.chainId);
+    });
+
+    return expectedChainIds;
+  }
+
+  function defineExpectedBridgeStateForSingleChainId(
+    chainId: number,
+    relocations: TestTokenRelocation[]
+  ): BridgeStateForChainId {
+    const expectedBridgeState: BridgeStateForChainId = {
+      requestedRelocationCount: 0,
+      processedRelocationCount: 0,
+      pendingRelocationCount: 0,
+      firstNonce: 0,
+      nonceCount: 1,
+      onChainRelocations: [defaultOnChainRelocation]
+    };
+    expectedBridgeState.requestedRelocationCount = countNumberArrayTotal(
+      relocations.map(
+        function (relocation: TestTokenRelocation): number {
+          return !!relocation.requested && relocation.chainId == chainId ? 1 : 0;
+        }
+      )
+    );
+
+    expectedBridgeState.processedRelocationCount = countNumberArrayTotal(
+      relocations.map(
+        function (relocation: TestTokenRelocation): number {
+          return !!relocation.processed && relocation.chainId == chainId ? 1 : 0;
+        }
+      )
+    );
+
+    relocations.forEach((relocation: TestTokenRelocation) => {
+      if (!!relocation.requested && relocation.chainId == chainId) {
+        expectedBridgeState.onChainRelocations[relocation.nonce] = toOnChainRelocation(relocation);
+      }
+    });
+    expectedBridgeState.onChainRelocations[expectedBridgeState.onChainRelocations.length] = defaultOnChainRelocation;
+    expectedBridgeState.nonceCount = expectedBridgeState.onChainRelocations.length;
+
+    expectedBridgeState.pendingRelocationCount =
+      expectedBridgeState.requestedRelocationCount - expectedBridgeState.processedRelocationCount;
+
+    return expectedBridgeState;
+  }
+
+  function defineExpectedBridgeStatesPerChainId(
+    relocations: TestTokenRelocation[]
+  ): Map<number, BridgeStateForChainId> {
+    const expectedChainIds: Set<number> = defineExpectedChainIds(relocations);
+    const expectedStatesPerChainId: Map<number, BridgeStateForChainId> = new Map<number, BridgeStateForChainId>();
+
+    expectedChainIds.forEach((chainId: number) => {
+      const expectedBridgeState: BridgeStateForChainId =
+        defineExpectedBridgeStateForSingleChainId(chainId, relocations);
+      expectedStatesPerChainId.set(chainId, expectedBridgeState);
+    });
+
+    return expectedStatesPerChainId;
+  }
+
+  function defineExpectedBridgeBalance(relocations: TestTokenRelocation[]): number {
+    return countNumberArrayTotal(
+      relocations.map(function (relocation: TestTokenRelocation): number {
+          if (
+            !!relocation.requested
+            && (operationMode === OperationMode.LockOrTransfer || !relocation.processed)
+            && !relocation.canceled
+          ) {
+            return relocation.amount;
+          } else {
+            return 0;
+          }
+        }
+      )
+    );
+  }
+
+  async function checkBridgeStatesPerChainId(expectedBridgeStatesPerChainId: Map<number, BridgeStateForChainId>) {
+    for (const expectedChainId of expectedBridgeStatesPerChainId.keys()) {
+      const expectedBridgeState: BridgeStateForChainId | undefined =
+        expectedBridgeStatesPerChainId.get(expectedChainId);
+      if (!expectedBridgeState) {
+        continue;
+      }
+      expect(
+        await tokenBridge.getPendingRelocationCounter(expectedChainId)
+      ).to.equal(
+        expectedBridgeState.pendingRelocationCount,
+        `Wrong pending relocation count, chainId=${expectedChainId}`
+      );
+      expect(
+        await tokenBridge.getLastProcessedRelocationNonce(expectedChainId)
+      ).to.equal(
+        expectedBridgeState.processedRelocationCount,
+        `Wrong requested relocation count, chainId=${expectedChainId}`
+      );
+      const actualRelocations = await tokenBridge.getRelocations(
+        expectedChainId,
+        expectedBridgeState.firstNonce,
+        expectedBridgeState.nonceCount
+      );
+      expect(actualRelocations.length).to.equal(expectedBridgeState.onChainRelocations.length);
+      for (let i = 0; i < expectedBridgeState.onChainRelocations.length; ++i) {
+        const onChainRelocation: OnChainRelocation = expectedBridgeState.onChainRelocations[i];
+        checkEquality(actualRelocations[i], onChainRelocation, i, expectedChainId);
+      }
+    }
+  }
+
+  async function checkRelocationStructures(relocations: TestTokenRelocation[]) {
+    for (let i = 0; i < relocations.length; ++i) {
+      const relocation = relocations[i];
+      if (relocation.requested) {
+        const actualRelocation = await tokenBridge.getRelocation(relocation.chainId, relocation.nonce);
+        checkEquality(actualRelocation, toOnChainRelocation(relocation), i, relocation.chainId);
+      }
+    }
+  }
+
+  async function checkBridgeState(relocations: TestTokenRelocation[]): Promise<void> {
+    const expectedBridgeStatesPerChainId: Map<number, BridgeStateForChainId> =
+      defineExpectedBridgeStatesPerChainId(relocations);
+    const expectedBridgeBalance: number = defineExpectedBridgeBalance(relocations);
+
+    await checkBridgeStatesPerChainId(expectedBridgeStatesPerChainId);
+    await checkRelocationStructures(relocations);
+    expect(await tokenMock.balanceOf(tokenBridge.address)).to.equal(expectedBridgeBalance);
+  }
+
+  beforeEach(async () => {
+    // Deploy BRLC
+    const TokenMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    tokenMock = await TokenMock.deploy();
+    await tokenMock.deployed();
+    await proveTx(tokenMock.initialize("BRL Coin", "BRLC"));
+
+    // Deploy TokenBridge
+    TokenBridge = await ethers.getContractFactory("TokenBridge");
+    tokenBridge = await TokenBridge.deploy();
+    await tokenBridge.deployed();
+    await proveTx(tokenBridge.initialize(tokenMock.address));
+
+    // Get user accounts
+    [deployer, user1, user2] = await ethers.getSigners();
+
+    // Roles
+    ownerRole = (await tokenBridge.OWNER_ROLE()).toLowerCase();
+    pauserRole = (await tokenBridge.PAUSER_ROLE()).toLowerCase();
+    rescuerRole = (await tokenBridge.RESCUER_ROLE()).toLowerCase();
+    bridgerRole = (await tokenBridge.BRIDGER_ROLE()).toLowerCase();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      tokenBridge.initialize(tokenMock.address)
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initial contract configuration should be as expected", async () => {
+    // The underlying contract address
+    expect(await tokenBridge.underlyingToken()).to.equal(tokenMock.address);
+
+    // The role admins
+    expect(await tokenBridge.getRoleAdmin(ownerRole)).to.equal(ownerRole);
+    expect(await tokenBridge.getRoleAdmin(pauserRole)).to.equal(ownerRole);
+    expect(await tokenBridge.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+    expect(await tokenBridge.getRoleAdmin(bridgerRole)).to.equal(ownerRole);
+
+    // The deployer should have the owner role, but not the other roles
+    expect(await tokenBridge.hasRole(ownerRole, deployer.address)).to.equal(true);
+    expect(await tokenBridge.hasRole(pauserRole, deployer.address)).to.equal(false);
+    expect(await tokenBridge.hasRole(rescuerRole, deployer.address)).to.equal(false);
+    expect(await tokenBridge.hasRole(bridgerRole, deployer.address)).to.equal(false);
+
+    // The initial contract state is unpaused
+    expect(await tokenBridge.paused()).to.equal(false);
+  });
+
+  describe("Configuration", async () => {
+    describe("Function 'setRelocationMode()'", async () => {
+      const chainId = 123;
+
+      it("Is reverted if is called not by the account with the owner role", async () => {
+        await expect(
+          tokenBridge.connect(user1).setRelocationMode(chainId, OperationMode.BurnOrMint)
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
+      });
+
+      it("Is reverted if the new mode is BurnOrMint and the token does not support bridge operations", async () => {
+        const otherTokenBridge: Contract = await TokenBridge.deploy();
+        await otherTokenBridge.deployed();
+        const fakeTokenAddress: string = deployer.address;
+        await proveTx(otherTokenBridge.initialize(fakeTokenAddress));
+        await expect(
+          otherTokenBridge.setRelocationMode(
+            chainId,
+            OperationMode.BurnOrMint
+          )
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_TOKEN_DOES_NOT_SUPPORT_BRIDGE_OPERATIONS);
+      });
+
+      it("Emits the correct events and updates the configuration correctly", async () => {
+        const relocationModeOld: OperationMode = await tokenBridge.getRelocationMode(chainId);
+        expect(relocationModeOld).to.equal(OperationMode.Unsupported);
+        await expect(
+          tokenBridge.setRelocationMode(chainId, OperationMode.BurnOrMint)
+        ).to.emit(
+          tokenBridge,
+          "SetRelocationMode"
+        ).withArgs(
+          chainId,
+          OperationMode.Unsupported,
+          OperationMode.BurnOrMint
+        );
+        const relocationModeNew: OperationMode = await tokenBridge.getRelocationMode(chainId);
+        expect(relocationModeNew).to.equal(OperationMode.BurnOrMint);
+
+        // Second call with the same argument should not emit an event
+        await expect(
+          tokenBridge.setRelocationMode(chainId, OperationMode.BurnOrMint)
+        ).not.to.emit(tokenBridge, "SetRelocationMode");
+
+        await expect(
+          tokenBridge.setRelocationMode(chainId, OperationMode.LockOrTransfer)
+        ).to.emit(
+          tokenBridge,
+          "SetRelocationMode"
+        ).withArgs(
+          chainId,
+          OperationMode.BurnOrMint,
+          OperationMode.LockOrTransfer
+        );
+        const relocationModeNew2: OperationMode = await tokenBridge.getRelocationMode(chainId);
+        expect(relocationModeNew2).to.equal(OperationMode.LockOrTransfer);
+
+        await expect(
+          tokenBridge.setRelocationMode(chainId, OperationMode.Unsupported)
+        ).to.emit(
+          tokenBridge,
+          "SetRelocationMode"
+        ).withArgs(
+          chainId,
+          OperationMode.LockOrTransfer,
+          OperationMode.Unsupported
+        );
+        const relocationModeNew3: OperationMode = await tokenBridge.getRelocationMode(chainId);
+        expect(relocationModeNew3).to.equal(OperationMode.Unsupported);
+      });
+    });
+
+    describe("Function 'setAccommodationMode()'", async () => {
+      const chainId = 123;
+
+      it("Is reverted if is called not by the account with the owner role", async () => {
+        await expect(
+          tokenBridge.connect(user1).setAccommodationMode(chainId, OperationMode.BurnOrMint)
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(user1.address, ownerRole));
+      });
+
+      it("Is reverted if the new mode is BurnOrMint and the token does not support bridge operations", async () => {
+        const otherTokenBridge: Contract = await TokenBridge.deploy();
+        await otherTokenBridge.deployed();
+        const fakeTokenAddress: string = deployer.address;
+        await proveTx(otherTokenBridge.initialize(fakeTokenAddress));
+        await expect(
+          otherTokenBridge.setAccommodationMode(chainId, OperationMode.BurnOrMint)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_TOKEN_DOES_NOT_SUPPORT_BRIDGE_OPERATIONS);
+      });
+
+      it("Emits the correct events and updates the configuration correctly", async () => {
+        const accommodationModeOld: OperationMode = await tokenBridge.getAccommodationMode(chainId);
+        expect(accommodationModeOld).to.equal(OperationMode.Unsupported);
+        await expect(
+          tokenBridge.setAccommodationMode(chainId, OperationMode.BurnOrMint)
+        ).to.emit(
+          tokenBridge,
+          "SetAccommodationMode"
+        ).withArgs(
+          chainId,
+          OperationMode.Unsupported,
+          OperationMode.BurnOrMint
+        );
+        const accommodationModeNew: OperationMode = await tokenBridge.getAccommodationMode(chainId);
+        expect(accommodationModeNew).to.equal(OperationMode.BurnOrMint);
+
+        // Second call with the same argument should not emit an event
+        await expect(
+          tokenBridge.setAccommodationMode(chainId, OperationMode.BurnOrMint)
+        ).not.to.emit(tokenBridge, "SetAccommodationMode");
+
+        await expect(
+          tokenBridge.setAccommodationMode(chainId, OperationMode.LockOrTransfer)
+        ).to.emit(
+          tokenBridge,
+          "SetAccommodationMode"
+        ).withArgs(
+          chainId,
+          OperationMode.BurnOrMint,
+          OperationMode.LockOrTransfer
+        );
+        const accommodationModeNew2: OperationMode = await tokenBridge.getAccommodationMode(chainId);
+        expect(accommodationModeNew2).to.equal(OperationMode.LockOrTransfer);
+
+        await expect(
+          tokenBridge.setAccommodationMode(chainId, OperationMode.Unsupported)
+        ).to.emit(
+          tokenBridge,
+          "SetAccommodationMode"
+        ).withArgs(
+          chainId,
+          OperationMode.LockOrTransfer,
+          OperationMode.Unsupported
+        );
+        const accommodationModeNew3: OperationMode = await tokenBridge.getAccommodationMode(chainId);
+        expect(accommodationModeNew3).to.equal(OperationMode.Unsupported);
+      });
+    });
+  });
+
+  describe("Interactions related to relocations in the BurnOrMint operation mode", async () => {
+
+    beforeEach(async () => {
+      operationMode = OperationMode.BurnOrMint;
+      await proveTx(tokenMock.setBridge(tokenBridge.address));
+    });
+
+    describe("Function 'requestRelocation()'", async () => {
+      let relocation: TestTokenRelocation;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 123,
+          account: user1,
+          amount: 456,
+          nonce: 1,
+        };
+        await setUpContractsForRelocations([relocation]);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseTokenBridge();
+        await expect(
+          tokenBridge.connect(relocation.account).requestRelocation(relocation.chainId, relocation.amount)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the token amount of the relocation is zero", async () => {
+        await expect(
+          tokenBridge.connect(relocation.account).requestRelocation(relocation.chainId, 0)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_RELOCATION_AMOUNT_IS_ZERO);
+      });
+
+      it("Is reverted if the relocation to the target chain is unsupported", async () => {
+        await expect(
+          tokenBridge.connect(relocation.account).requestRelocation(relocation.chainId + 1, relocation.amount)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_RELOCATION_IS_UNSUPPORTED);
+      });
+
+      it("Is reverted if the token does not support the bridge", async () => {
+        await proveTx(tokenMock.setBridge(deployer.address));
+        await expect(
+          tokenBridge.connect(relocation.account).requestRelocation(relocation.chainId, relocation.amount)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_UNSUPPORTING_TOKEN);
+      });
+
+      it("Is reverted if the user has not enough token balance", async () => {
+        const excessTokenAmount: number = relocation.amount + 1;
+        await expect(
+          tokenBridge.connect(relocation.account).requestRelocation(relocation.chainId, excessTokenAmount)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+      });
+
+      it("Transfers tokens as expected, emits the correct event, changes the state properly", async () => {
+        await checkBridgeState([relocation]);
+        await expect(
+          tokenBridge.connect(relocation.account).requestRelocation(relocation.chainId, relocation.amount)
+        ).to.changeTokenBalances(
+          tokenMock,
+          [tokenBridge, relocation.account],
+          [+relocation.amount, -relocation.amount]
+        ).and.to.emit(
+          tokenBridge,
+          "RequestRelocation"
+        ).withArgs(
+          relocation.chainId,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce
+        );
+        relocation.requested = true;
+        await checkBridgeState([relocation]);
+      });
+    });
+
+    describe("Function 'cancelRelocation()'", async () => {
+      let relocation: TestTokenRelocation;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 234,
+          account: user1,
+          amount: 567,
+          nonce: 1,
+        };
+        await setUpContractsForRelocations([relocation]);
+        await requestRelocations([relocation]);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseTokenBridge();
+        await expect(
+          tokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller did not request the relocation", async () => {
+        await expect(
+          tokenBridge.connect(user2).cancelRelocation(relocation.chainId, relocation.nonce)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_TRANSACTION_SENDER_IS_UNAUTHORIZED);
+      });
+
+      it("Is reverted if a relocation with the nonce has already processed", async () => {
+        await expect(
+          tokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce - 1)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_TRANSACTION_SENDER_IS_UNAUTHORIZED);
+      });
+
+      it("Is reverted if a relocation with the nonce does not exists", async () => {
+        await expect(
+          tokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce + 1)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_TRANSACTION_SENDER_IS_UNAUTHORIZED);
+      });
+
+      it("Transfers the tokens as expected, emits the correct event, changes the state properly", async () => {
+        await checkBridgeState([relocation]);
+        await expect(
+          tokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce)
+        ).to.changeTokenBalances(
+          tokenMock,
+          [tokenBridge, relocation.account],
+          [-relocation.amount, +relocation.amount]
+        ).and.to.emit(
+          tokenBridge,
+          "CancelRelocation"
+        ).withArgs(
+          relocation.chainId,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce
+        );
+        relocation.canceled = true;
+        await checkBridgeState([relocation]);
+      });
+    });
+
+    describe("Function 'cancelRelocations()'", async () => {
+      const chainId = 12;
+
+      let relocations: TestTokenRelocation[];
+      let relocator: SignerWithAddress;
+      let relocationNonces: number[];
+
+      beforeEach(async () => {
+        relocations = [
+          {
+            chainId: chainId,
+            account: user1,
+            amount: 34,
+            nonce: 1,
+          },
+          {
+            chainId: chainId,
+            account: user2,
+            amount: 56,
+            nonce: 2,
+          },
+        ];
+        relocationNonces = relocations.map((relocation: TestTokenRelocation) => relocation.nonce);
+        relocator = user2;
+        await setUpContractsForRelocations(relocations);
+        await requestRelocations(relocations);
+        await setBridgerRole(relocator);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseTokenBridge();
+        await expect(
+          tokenBridge.connect(relocator).cancelRelocations(chainId, relocationNonces)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller does not have the bridger role", async () => {
+        await expect(
+          tokenBridge.connect(deployer).cancelRelocations(chainId, relocationNonces)
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, bridgerRole));
+      });
+
+      it("Is reverted if the input array of nonces is empty", async () => {
+        await expect(
+          tokenBridge.connect(relocator).cancelRelocations(chainId, [])
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_RELOCATION_ARRAY_OF_NONCES_IS_EMPTY);
+      });
+
+      it("Is reverted if some input nonce is less than the lowest nonce of pending relocations", async () => {
+        await expect(
+          tokenBridge.connect(relocator).cancelRelocations(
+            chainId,
+            [
+              Math.min(...relocationNonces),
+              Math.min(...relocationNonces) - 1,
+            ]
+          )
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_RELOCATION_IS_ALREADY_PROCESSED);
+      });
+
+      it("Is reverted if some input nonce is greater than the highest nonce of pending relocations", async () => {
+        await expect(
+          tokenBridge.connect(relocator).cancelRelocations(
+            chainId,
+            [
+              Math.max(...relocationNonces),
+              Math.max(...relocationNonces) + 1
+            ]
+          )
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_RELOCATION_DOES_NOT_EXIST);
+      });
+
+      it("Is reverted if a relocation with some nonce is already canceled", async () => {
+        await cancelRelocations([relocations[1]]);
+        await expect(
+          tokenBridge.connect(relocator).cancelRelocations(chainId, relocationNonces)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_RELOCATION_IS_ALREADY_CANCELED);
+      });
+
+      it("Transfers the tokens as expected, emits the correct events, changes the state properly", async () => {
+        await checkBridgeState(relocations);
+
+        const relocationAmounts: number[] = relocations.map((relocation: TestTokenRelocation) => relocation.amount);
+        const relocationAccounts: SignerWithAddress[] =
+          relocations.map((relocation: TestTokenRelocation) => relocation.account);
+        const relocationAmountTotal: number = countNumberArrayTotal(relocationAmounts);
+
+        await expect(
+          tokenBridge.connect(relocator).cancelRelocations(chainId, relocationNonces)
+        ).to.changeTokenBalances(
+          tokenMock,
+          [tokenBridge, ...relocationAccounts],
+          [-(relocationAmountTotal), ...relocationAmounts]
+        ).and.to.emit(
+          tokenBridge,
+          "CancelRelocation"
+        ).withArgs(
+          chainId,
+          relocations[0].account.address,
+          relocations[0].amount,
+          relocations[0].nonce
+        ).and.to.emit(
+          tokenBridge,
+          "CancelRelocation"
+        ).withArgs(
+          chainId,
+          relocations[1].account.address,
+          relocations[1].amount,
+          relocations[1].nonce
+        );
+        relocations.forEach((relocation: TestTokenRelocation) => relocation.canceled = true);
+        await checkBridgeState(relocations);
+      });
+    });
+
+    describe("Function 'relocate()'", async () => {
+      const relocationCount = 1;
+
+      let relocation: TestTokenRelocation;
+      let relocator: SignerWithAddress;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 345,
+          account: user1,
+          amount: 678,
+          nonce: 1,
+        };
+        relocator = user2;
+
+        await setUpContractsForRelocations([relocation]);
+        await requestRelocations([relocation]);
+        await setBridgerRole(relocator);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseTokenBridge();
+        await expect(
+          tokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller does not have the bridger role", async () => {
+        await expect(
+          tokenBridge.connect(deployer).relocate(relocation.chainId, relocationCount)
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, bridgerRole));
+      });
+
+      it("Is reverted if the relocation count is zero", async () => {
+        await expect(
+          tokenBridge.connect(relocator).relocate(relocation.chainId, 0)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_RELOCATION_COUNT_IS_ZERO);
+      });
+
+      it("Is reverted if the relocation count exceeds the number of pending relocations", async () => {
+        await expect(
+          tokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount + 1)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_THERE_IS_LACK_PENDING_RELOCATIONS);
+      });
+
+      it("Is reverted if the token does not support the bridge", async () => {
+        await proveTx(tokenMock.setBridge(deployer.address));
+        await expect(
+          tokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_UNSUPPORTING_TOKEN);
+      });
+
+      it("Is reverted if burning of tokens had failed", async () => {
+        await proveTx(tokenMock.disableBurningForBridging());
+        await expect(
+          tokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_BURNING_OF_TOKENS_FAILED);
+      });
+
+      it("Burns no tokens, emits no events if the relocation was canceled", async () => {
+        await cancelRelocations([relocation]);
+        await checkBridgeState([relocation]);
+        const balanceBefore: BigNumber = await tokenMock.balanceOf(tokenBridge.address);
+        await expect(
+          tokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).and.not.to.emit(
+          tokenBridge,
+          "Relocate"
+        );
+        const balanceAfter: BigNumber = await tokenMock.balanceOf(tokenBridge.address);
+        expect(balanceAfter.sub(balanceBefore)).to.equal(0);
+        markRelocationsAsProcessed([relocation]);
+        await checkBridgeState([relocation]);
+      });
+
+      it("Burns tokens as expected, emits the correct event, changes the state properly", async () => {
+        await expect(
+          tokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.changeTokenBalances(
+          tokenMock,
+          [tokenBridge, user1, user2],
+          [-relocation.amount, 0, 0]
+        ).and.to.emit(
+          tokenBridge,
+          "Relocate"
+        ).withArgs(
+          relocation.chainId,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce,
+          operationMode
+        );
+        markRelocationsAsProcessed([relocation]);
+        await checkBridgeState([relocation]);
+      });
+    });
+
+    describe("Complex scenario for a single chain", async () => {
+      const chainId = 123;
+
+      let relocations: TestTokenRelocation[];
+      let relocator: SignerWithAddress;
+
+      beforeEach(async () => {
+        relocations = [
+          {
+            chainId: chainId,
+            account: user1,
+            amount: 234,
+            nonce: 1,
+          },
+          {
+            chainId: chainId,
+            account: user1,
+            amount: 345,
+            nonce: 2,
+          },
+          {
+            chainId: chainId,
+            account: user2,
+            amount: 456,
+            nonce: 3,
+          },
+          {
+            chainId: chainId,
+            account: deployer,
+            amount: 567,
+            nonce: 4,
+          },
+        ];
+        relocator = user2;
+        await setUpContractsForRelocations(relocations);
+        await setBridgerRole(relocator);
+      });
+
+      it("Executes as expected", async () => {
+        // Request first 3 relocations
+        await requestRelocations([relocations[0], relocations[1], relocations[2]]);
+        await checkBridgeState(relocations);
+
+        // Process the first relocation
+        await proveTx(tokenBridge.connect(relocator).relocate(chainId, 1));
+        markRelocationsAsProcessed([relocations[0]]);
+        await checkBridgeState(relocations);
+
+        // Try to cancel already processed relocation
+        await expect(
+          tokenBridge.connect(relocations[0].account).cancelRelocation(chainId, relocations[0].nonce)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_RELOCATION_IS_ALREADY_PROCESSED);
+
+        // Try to cancel a relocation of another user
+        await expect(
+          tokenBridge.connect(relocations[1].account).cancelRelocation(chainId, relocations[2].nonce)
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_TRANSACTION_SENDER_IS_UNAUTHORIZED);
+
+        // Try to cancel several relocations including the processed one
+        await expect(
+          tokenBridge.connect(relocator).cancelRelocations(chainId, [
+            relocations[2].nonce,
+            relocations[1].nonce,
+            relocations[0].nonce,
+          ])
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_RELOCATION_IS_ALREADY_PROCESSED);
+
+        // Try to cancel several relocations including one that is out of the pending range
+        await expect(
+          tokenBridge.connect(relocator).cancelRelocations(chainId, [
+            relocations[3].nonce,
+            relocations[2].nonce,
+            relocations[1].nonce,
+          ])
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_RELOCATION_DOES_NOT_EXIST);
+
+        // Check that state of the bridge has not changed
+        await checkBridgeState(relocations);
+
+        // Request another relocation
+        await requestRelocations([relocations[3]]);
+        await checkBridgeState(relocations);
+
+        // Cancel two last relocations
+        await proveTx(
+          tokenBridge.connect(relocator).cancelRelocations(
+            chainId,
+            [relocations[3].nonce, relocations[2].nonce]
+          )
+        );
+        [relocations[3], relocations[2]].forEach((relocation: TestTokenRelocation) => relocation.canceled = true);
+        await checkBridgeState(relocations);
+
+        // Process all the pending relocations
+        await proveTx(tokenBridge.connect(relocator).relocate(chainId, 3));
+        markRelocationsAsProcessed(relocations);
+        await checkBridgeState(relocations);
+      });
+    });
+
+    describe("Complex scenario for several chains", async () => {
+      const chainId1 = 123;
+      const chainId2 = 234;
+
+      let relocations: TestTokenRelocation[];
+      let relocator: SignerWithAddress;
+      let relocationCountForChain1: number;
+      let relocationCountForChain2: number;
+
+      beforeEach(async () => {
+        relocations = [
+          {
+            chainId: chainId1,
+            account: user1,
+            amount: 345,
+            nonce: 1,
+          },
+          {
+            chainId: chainId1,
+            account: user1,
+            amount: 456,
+            nonce: 2,
+          },
+          {
+            chainId: chainId2,
+            account: user2,
+            amount: 567,
+            nonce: 1,
+          },
+          {
+            chainId: chainId2,
+            account: deployer,
+            amount: 678,
+            nonce: 2,
+          },
+        ];
+        relocator = user2;
+        relocationCountForChain1 = countRelocationsForChainId(relocations, chainId1);
+        relocationCountForChain2 = countRelocationsForChainId(relocations, chainId2);
+        await setUpContractsForRelocations(relocations);
+        await setBridgerRole(relocator);
+      });
+
+      it("Executes as expected", async () => {
+        // Request all relocations
+        await requestRelocations(relocations);
+        await checkBridgeState(relocations);
+
+        // Cancel some relocations
+        await cancelRelocations([relocations[1], relocations[2]]);
+        await checkBridgeState(relocations);
+
+        // Process all the pending relocations in all the chains
+        await proveTx(tokenBridge.connect(relocator).relocate(chainId1, relocationCountForChain1));
+        await proveTx(tokenBridge.connect(relocator).relocate(chainId2, relocationCountForChain2));
+        markRelocationsAsProcessed(relocations);
+        await checkBridgeState(relocations);
+      });
+    });
+  });
+
+  describe("Interactions related to relocations in the LockOrTransfer operation mode", async () => {
+
+    beforeEach(async () => {
+      operationMode = OperationMode.LockOrTransfer;
+    });
+
+    describe("Function 'requestRelocation()'", async () => {
+      let relocation: TestTokenRelocation;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 123,
+          account: user1,
+          amount: 456,
+          nonce: 1,
+        };
+        await setUpContractsForRelocations([relocation]);
+      });
+
+      it("Transfers tokens as expected, emits the correct event, changes the state properly", async () => {
+        await checkBridgeState([relocation]);
+        await expect(
+          tokenBridge.connect(relocation.account).requestRelocation(
+            relocation.chainId,
+            relocation.amount
+          )
+        ).to.changeTokenBalances(
+          tokenMock,
+          [tokenBridge, relocation.account],
+          [+relocation.amount, -relocation.amount,]
+        ).and.to.emit(
+          tokenBridge,
+          "RequestRelocation"
+        ).withArgs(
+          relocation.chainId,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce
+        );
+        relocation.requested = true;
+        await checkBridgeState([relocation]);
+      });
+    });
+
+    describe("Function 'relocate()'", async () => {
+      const relocationCount = 1;
+
+      let relocation: TestTokenRelocation;
+      let relocator: SignerWithAddress;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 345,
+          account: user1,
+          amount: 678,
+          nonce: 1,
+        };
+        relocator = user2;
+
+        await setUpContractsForRelocations([relocation]);
+        await requestRelocations([relocation]);
+        await setBridgerRole(relocator);
+      });
+
+      it("Burns no tokens, emits the correct event, changes the state properly", async () => {
+        await expect(
+          tokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.changeTokenBalances(
+          tokenMock,
+          [tokenBridge, relocation.account],
+          [0, 0]
+        ).and.to.emit(
+          tokenBridge,
+          "Relocate"
+        ).withArgs(
+          relocation.chainId,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce,
+          OperationMode.LockOrTransfer
+        );
+        markRelocationsAsProcessed([relocation]);
+        await checkBridgeState([relocation]);
+      });
+    });
+  });
+
+  describe("Interactions related to accommodations in the BurnOrMint operation mode", async () => {
+    describe("Function 'accommodate()'", async () => {
+      const chainId = 123;
+      const firstRelocationNonce = 1;
+
+      let relocations: TestTokenRelocation[];
+      let accommodator: SignerWithAddress;
+      let onChainRelocations: OnChainRelocation[];
+
+      beforeEach(async () => {
+        operationMode = OperationMode.BurnOrMint;
+        await proveTx(tokenMock.setBridge(tokenBridge.address));
+        relocations = [
+          {
+            chainId: chainId,
+            account: user1,
+            amount: 456,
+            nonce: firstRelocationNonce,
+            canceled: true,
+          },
+          {
+            chainId: chainId,
+            account: user2,
+            amount: 789,
+            nonce: firstRelocationNonce + 1,
+          },
+        ];
+        accommodator = user2;
+        onChainRelocations = relocations.map(toOnChainRelocation);
+
+        await proveTx(tokenBridge.setAccommodationMode(chainId, operationMode));
+        await setBridgerRole(accommodator);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseTokenBridge();
+        await expect(
+          tokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller does not have the bridger role", async () => {
+        await expect(
+          tokenBridge.connect(deployer).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, bridgerRole));
+      });
+
+      it("Is reverted if the accommodation from the target chain is unsupported", async () => {
+        await expect(
+          tokenBridge.connect(accommodator).accommodate(
+            chainId + 1,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_ACCOMMODATION_IS_UNSUPPORTED);
+      });
+
+      it("Is reverted if the first relocation nonce is zero", async () => {
+        await expect(
+          tokenBridge.connect(accommodator).accommodate(
+            chainId,
+            0,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_ACCOMMODATION_FIRST_NONCE_IS_ZERO);
+      });
+
+      it("Is reverted if the first relocation nonce does not equal the last accommodation nonce +1", async () => {
+        await expect(
+          tokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce + 1,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_ACCOMMODATION_NONCE_MISMATCH);
+      });
+
+      it("Is reverted if the input array of relocations is empty", async () => {
+        await expect(
+          tokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            []
+          )
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_INPUT_ARRAY_OF_RELOCATIONS_IS_EMPTY);
+      });
+
+      it("Is reverted if the token does not support the bridge", async () => {
+        await proveTx(tokenMock.setBridge(deployer.address));
+        await expect(
+          tokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_UNSUPPORTING_TOKEN);
+      });
+
+      it("Is reverted if one of the input accounts has zero address", async () => {
+        onChainRelocations[1].account = ethers.constants.AddressZero;
+        await expect(
+          tokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_ACCOMMODATION_ACCOUNT_IS_ZERO_ADDRESS);
+      });
+
+      it("Is reverted if one of the input amounts is zero", async () => {
+        onChainRelocations[1].amount = ethers.constants.Zero;
+        await expect(
+          tokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_ACCOMMODATION_AMOUNT_IS_ZERO);
+      });
+
+      it("Is reverted if minting of tokens had failed", async () => {
+        await proveTx(tokenMock.disableMintingForBridging());
+        await expect(
+          tokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.be.revertedWithCustomError(tokenBridge, REVERT_ERROR_IF_MINTING_OF_TOKENS_FAILED);
+      });
+
+      it("Mints tokens as expected, emits the correct events, changes the state properly", async () => {
+        const relocationAccountAddresses: string[] =
+          relocations.map((relocation: TestTokenRelocation) => relocation.account.address);
+        const expectedMintingAmounts: number[] =
+          relocations.map((relocation: TestTokenRelocation) => !!relocation.canceled ? 0 : relocation.amount);
+        await expect(
+          tokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.changeTokenBalances(
+          tokenMock,
+          [tokenBridge, ...relocationAccountAddresses],
+          [0, ...expectedMintingAmounts]
+        ).and.to.emit(
+          tokenBridge,
+          "Accommodate"
+        ).withArgs(
+          chainId,
+          relocations[1].account.address,
+          relocations[1].amount,
+          relocations[1].nonce,
+          operationMode
+        );
+        expect(
+          await tokenBridge.getLastAccommodationNonce(chainId)
+        ).to.equal(relocations[relocations.length - 1].nonce);
+      });
+    });
+  });
+
+  describe("Interactions related to accommodations in the LockOrTransfer operation mode", async () => {
+
+    describe("Function 'accommodate()'", async () => {
+      const chainId = 123;
+      const firstRelocationNonce = 1;
+
+      let relocations: TestTokenRelocation[];
+      let accommodator: SignerWithAddress;
+      let onChainRelocations: OnChainRelocation[];
+
+      beforeEach(async () => {
+        operationMode = OperationMode.LockOrTransfer;
+        relocations = [
+          {
+            chainId: chainId,
+            account: user1,
+            amount: 456,
+            nonce: firstRelocationNonce,
+            canceled: true,
+          },
+          {
+            chainId: chainId,
+            account: user2,
+            amount: 789,
+            nonce: firstRelocationNonce + 1,
+          },
+        ];
+        accommodator = user2;
+        onChainRelocations = relocations.map(toOnChainRelocation);
+
+        await proveTx(tokenBridge.setAccommodationMode(chainId, operationMode));
+        await setBridgerRole(accommodator);
+      });
+
+      it("Transfers tokens as expected, emits the correct events, changes the state properly", async () => {
+        const relocationAccountAddresses: string[] =
+          relocations.map((relocation: TestTokenRelocation) => relocation.account.address);
+        const expectedTransferAmounts: number[] =
+          relocations.map((relocation: TestTokenRelocation) => !!relocation.canceled ? 0 : relocation.amount);
+        const expectedBridgeBalanceChange: number = countNumberArrayTotal(expectedTransferAmounts);
+        await proveTx(tokenMock.mint(tokenBridge.address, expectedBridgeBalanceChange));
+        await expect(
+          tokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            onChainRelocations
+          )
+        ).to.changeTokenBalances(
+          tokenMock,
+          [tokenBridge, ...relocationAccountAddresses],
+          [-expectedBridgeBalanceChange, ...expectedTransferAmounts]
+        ).and.to.emit(
+          tokenBridge,
+          "Accommodate"
+        ).withArgs(
+          chainId,
+          relocations[1].account.address,
+          relocations[1].amount,
+          relocations[1].nonce,
+          operationMode
+        );
+        expect(
+          await tokenBridge.getLastAccommodationNonce(chainId)
+        ).to.equal(relocations[relocations.length - 1].nonce);
+      });
+    });
+  });
+});

--- a/test/base/PauseControlUpgradeable.test.ts
+++ b/test/base/PauseControlUpgradeable.test.ts
@@ -1,0 +1,108 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
+
+describe("Contract 'PauseControlUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+
+  let pauseControlMock: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+  let ownerRole: string;
+  let pauserRole: string;
+
+  beforeEach(async () => {
+    // Deploy the contract under test
+    const PauseControlMock: ContractFactory = await ethers.getContractFactory("PauseControlUpgradeableMock");
+    pauseControlMock = await PauseControlMock.deploy();
+    await pauseControlMock.deployed();
+    await proveTx(pauseControlMock.initialize());
+
+    // Accounts
+    [deployer, user] = await ethers.getSigners();
+
+    // Roles
+    ownerRole = (await pauseControlMock.OWNER_ROLE()).toLowerCase();
+    pauserRole = (await pauseControlMock.PAUSER_ROLE()).toLowerCase();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      pauseControlMock.initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The init function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(
+      pauseControlMock.call_parent_initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The init unchained function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(
+      pauseControlMock.call_parent_initialize_unchained()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The initial contract configuration should be as expected", async () => {
+    // The role admins
+    expect(await pauseControlMock.getRoleAdmin(ownerRole)).to.equal(ethers.constants.HashZero);
+    expect(await pauseControlMock.getRoleAdmin(pauserRole)).to.equal(ownerRole);
+
+    // The deployer should have the owner role, but not the other roles
+    expect(await pauseControlMock.hasRole(ownerRole, deployer.address)).to.equal(true);
+    expect(await pauseControlMock.hasRole(pauserRole, deployer.address)).to.equal(false);
+
+    // The initial contract state is unpaused
+    expect(await pauseControlMock.paused()).to.equal(false);
+  });
+
+  describe("Function 'pause()'", async () => {
+    beforeEach(async () => {
+      await proveTx(pauseControlMock.grantRole(pauserRole, user.address));
+    });
+
+    it("Is reverted if is called by an account without the pauser role", async () => {
+      await expect(
+        pauseControlMock.pause()
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, pauserRole));
+    });
+
+    it("Executes successfully and emits the correct event", async () => {
+      await expect(
+        pauseControlMock.connect(user).pause()
+      ).to.emit(
+        pauseControlMock,
+        "Paused"
+      ).withArgs(user.address);
+      expect(await pauseControlMock.paused()).to.equal(true);
+    });
+  });
+
+  describe("Function 'unpause()'", async () => {
+    beforeEach(async () => {
+      await proveTx(pauseControlMock.grantRole(pauserRole, user.address));
+      await proveTx(pauseControlMock.connect(user).pause());
+    });
+
+    it("Is reverted if is called by an account without the pauser role", async () => {
+      await expect(
+        pauseControlMock.unpause()
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, pauserRole));
+    });
+
+    it("Executes successfully and emits the correct event", async () => {
+      await expect(
+        pauseControlMock.connect(user).unpause()
+      ).to.emit(
+        pauseControlMock,
+        "Unpaused"
+      ).withArgs(user.address);
+      expect(await pauseControlMock.paused()).to.equal(false);
+    });
+  });
+});

--- a/test/base/RescueControlUpgradeable.test.ts
+++ b/test/base/RescueControlUpgradeable.test.ts
@@ -1,0 +1,107 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
+
+describe("Contract 'RescueControlUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+
+  let rescueControlMock: Contract;
+  let tokenMock: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+  let ownerRole: string;
+  let rescuerRole: string;
+
+  beforeEach(async () => {
+    // Deploy the token mock contract
+    const TokenMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    tokenMock = await TokenMock.deploy();
+    await tokenMock.deployed();
+    await proveTx(tokenMock.initialize("BRL Coin", "BRLC"));
+
+    // Deploy the contract under test
+    const RescueControlMock: ContractFactory = await ethers.getContractFactory("RescueControlUpgradeableMock");
+    rescueControlMock = await RescueControlMock.deploy();
+    await rescueControlMock.deployed();
+    await proveTx(rescueControlMock.initialize());
+
+    // Accounts
+    [deployer, user] = await ethers.getSigners();
+
+    // Roles
+    ownerRole = (await rescueControlMock.OWNER_ROLE()).toLowerCase();
+    rescuerRole = (await rescueControlMock.RESCUER_ROLE()).toLowerCase();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      rescueControlMock.initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The init function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(
+      rescueControlMock.call_parent_initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The init unchained function of the ancestor contract can't be called outside the init process", async () => {
+    await expect(
+      rescueControlMock.call_parent_initialize_unchained()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+  });
+
+  it("The initial contract configuration should be as expected", async () => {
+    // The role admins
+    expect(await rescueControlMock.getRoleAdmin(ownerRole)).to.equal(ethers.constants.HashZero);
+    expect(await rescueControlMock.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+
+    // The deployer should have the owner role, but not the other roles
+    expect(await rescueControlMock.hasRole(ownerRole, deployer.address)).to.equal(true);
+    expect(await rescueControlMock.hasRole(rescuerRole, deployer.address)).to.equal(false);
+  });
+
+  describe("Function 'rescueERC20()'", async () => {
+    const tokenAmount = 123;
+
+    beforeEach(async () => {
+      await proveTx(tokenMock.mint(rescueControlMock.address, tokenAmount));
+      await proveTx(rescueControlMock.grantRole(rescuerRole, user.address));
+    });
+
+    it("Is reverted if is called by an account without the rescuer role", async () => {
+      await expect(
+        rescueControlMock.rescueERC20(
+          tokenMock.address,
+          deployer.address,
+          tokenAmount
+        )
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, rescuerRole));
+    });
+
+    it("Executes successfully, transfers tokens as expected, emits the correct event", async () => {
+      await expect(
+        rescueControlMock.connect(user).rescueERC20(
+          tokenMock.address,
+          deployer.address,
+          tokenAmount
+        )
+      ).to.changeTokenBalances(
+        tokenMock,
+        [rescueControlMock, deployer, user],
+        [-tokenAmount, +tokenAmount, 0]
+      ).and.to.emit(
+        tokenMock,
+        "Transfer"
+      ).withArgs(
+        rescueControlMock.address,
+        deployer.address,
+        tokenAmount
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Main changes
1. The multi-token bridge and single token bridge contracts have been developed.
2. The terms that are used in relation to bridge contracts:
    * relocation -- the relocation of tokens from one chain (a source chain) to another one (a destination chain). Unless otherwise stated, the source chain is the current chain;
     * to relocate -- to move tokens from the current chain to another one;
     * accommodation -- placing tokens coming from another chain in the current chain;
     * to accommodate -- to meet a relocation coming from another chain and place its tokens in the current chain.
3. The bridges can work in two modes: `BurnOrMint` and `LockOrTransfer`. In the first mode the bridges burn tokens in the source blockchain and mint the equal amount of tokens in the destination blockchain. In the second mode the bridges lock tokens gotten from a user on their accounts in the source blockchain and transfer the equal amount of tokens to a user in the destination blockchain.
4. The modes are configured separately for each token and each source or destination blockchain of a bridge. It is the reason of the `universal` word in the name of this PR.
5. Only tokens that implement the `IERC20Bridgeable` interface can be relocated through a bridge working in the `BurnOrMint` mode. For other tokens the `LockOrTransfer` mode must be used.
6. To restrict access to some functions of the bridges the roles are used based on the [OpenZeppelin access control contract](https://docs.openzeppelin.com/contracts/4.x/access-control).
7. The following roles are currently used in the contract:
    * `OWNER_ROLE` -- an account with this role owns the contract and can grant and remove other roles to/from accounts. 
    * `PAUSER_ROLE` -- an account with this role is allowed to pause and unpause the contract.
    * `RESCUER_ROLE` -- an account with this role is allowed to withdraw tokens from the contract's account.
    * `BRIDGER_ROLE` -- an account with this role is allowed to execute relocate and accommodate functions of the contract.

### Testing and coverage
The updated and newly developed tests have been successfully run on the following blockchains:
1. Internal Hardhat net.
2. Substrate with Frontier layer built from the [cloudwalk-network](https://github.com/cloudwalk/cloudwalk-network) repo, commit [350445547016ce83c5ce781ac8871194439b0e4f](https://github.com/cloudwalk/cloudwalk-network/commit/350445547016ce83c5ce781ac8871194439b0e4f) with tag `mainnet-v1.0.2`.

_NOTE 1_: When running a local node of Substrate with Frontier layer for testing use the node in the archive mode like in the following command:
```bash
./target/release/cloudwalk-network-node --dev --tmp --pruning archive
```
Test coverage is 100 %:
![image](https://user-images.githubusercontent.com/97302011/189328635-0b701808-8a01-43e9-a653-7dae85d5d593.png)