### PR TITLE
Deploy guard and upgrade bridge

### DIFF
--- a/.openzeppelin/goerli.json
+++ b/.openzeppelin/goerli.json
@@ -9,6 +9,11 @@
       "address": "0xa9a068A0E8Fb35C4c509FED72472df83FC9667D3",
       "txHash": "0x49559e0224c4d77a482bc9715b68ab0d96114f397b9c4ebb710f3acf366866eb",
       "kind": "transparent"
+    },
+    {
+      "address": "0x68597B4F5c46f777B87EfBe91904EeA3c32D11FC",
+      "txHash": "0xa472bc648301c871dba87ac8f6d317c8237128e06e2ed85b15dd99428d0a1158",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -794,6 +799,433 @@
               {
                 "label": "status",
                 "type": "t_enum(RelocationStatus)3944",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(RoleData)245_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "3711b38f96d53ef973f2d9a17c6aa1735fdd60c4d8a7bb649c24bd74d7b0f29f": {
+      "address": "0xD804d9F129fa3155aA76FbB1d468e673d3d5d8fF",
+      "txHash": "0x34df07bf4505091e4df6e1d4e6025da629fe5dc04dd31fb37e281b9cadf8c6ee",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_bridge",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_address",
+            "contract": "BridgeGuardStorage",
+            "src": "contracts\\BridgeGuardStorage.sol:13"
+          },
+          {
+            "label": "_accommodationGuards",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_struct(Guard)4569_storage))",
+            "contract": "BridgeGuardStorage",
+            "src": "contracts\\BridgeGuardStorage.sol:16"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_struct(Guard)4569_storage)": {
+            "label": "mapping(address => struct IBridgeGuardTypes.Guard)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_struct(Guard)4569_storage))": {
+            "label": "mapping(uint256 => mapping(address => struct IBridgeGuardTypes.Guard))",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Guard)4569_storage": {
+            "label": "struct IBridgeGuardTypes.Guard",
+            "members": [
+              {
+                "label": "timeFrame",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "volumeLimit",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "lastResetTime",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "currentVolume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "4f7caf4e0db381195fdd480111c54ffd6d930e633d8443144d2b79104ff757e5": {
+      "address": "0x70D93a27FfC58A48bAA9EABa6b7A3F6D42FB26e7",
+      "txHash": "0xbeebdb6674db09dd0a65a079fab61482489080de7ca8eee24f17dbbb659495c7",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)245_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_pendingRelocationCounters",
+            "offset": 0,
+            "slot": "501",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:14"
+          },
+          {
+            "label": "_lastProcessedRelocationNonces",
+            "offset": 0,
+            "slot": "502",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:17"
+          },
+          {
+            "label": "_relocationModes",
+            "offset": 0,
+            "slot": "503",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_enum(OperationMode)4633))",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:20"
+          },
+          {
+            "label": "_relocations",
+            "offset": 0,
+            "slot": "504",
+            "type": "t_mapping(t_uint256,t_mapping(t_uint256,t_struct(Relocation)4650_storage))",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:23"
+          },
+          {
+            "label": "_accommodationModes",
+            "offset": 0,
+            "slot": "505",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_enum(OperationMode)4633))",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:26"
+          },
+          {
+            "label": "_lastAccommodationNonces",
+            "offset": 0,
+            "slot": "506",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:29"
+          },
+          {
+            "label": "_bridgeGuard",
+            "offset": 0,
+            "slot": "507",
+            "type": "t_address",
+            "contract": "MultiTokenBridgeStorageV2",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:38"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(OperationMode)4633": {
+            "label": "enum IMultiTokenBridgeTypes.OperationMode",
+            "members": [
+              "Unsupported",
+              "BurnOrMint",
+              "LockOrTransfer"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(RelocationStatus)4640": {
+            "label": "enum IMultiTokenBridgeTypes.RelocationStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Canceled",
+              "Processed",
+              "Revoked",
+              "Aborted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_enum(OperationMode)4633)": {
+            "label": "mapping(address => enum IMultiTokenBridgeTypes.OperationMode)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)245_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_enum(OperationMode)4633))": {
+            "label": "mapping(uint256 => mapping(address => enum IMultiTokenBridgeTypes.OperationMode))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_uint256,t_struct(Relocation)4650_storage))": {
+            "label": "mapping(uint256 => mapping(uint256 => struct IMultiTokenBridgeTypes.Relocation))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Relocation)4650_storage)": {
+            "label": "mapping(uint256 => struct IMultiTokenBridgeTypes.Relocation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Relocation)4650_storage": {
+            "label": "struct IMultiTokenBridgeTypes.Relocation",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(RelocationStatus)4640",
                 "offset": 0,
                 "slot": "3"
               }

--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -9,6 +9,11 @@
       "address": "0x4e3512Cd8E36e94a23c3832271a2fF2B7357ddfc",
       "txHash": "0x3f37408321ed21c8c7c3a05259f4cc2e4860aba372b42f67666432ebd78c9128",
       "kind": "transparent"
+    },
+    {
+      "address": "0x06A13288B0E2746D12D4f91EDCE1cAaCDc4409DC",
+      "txHash": "0x4cc9ed4ba683af143446f50a96936daf05e5d4b5e43adcf4c6ae424715faadcb",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -794,6 +799,433 @@
               {
                 "label": "status",
                 "type": "t_enum(RelocationStatus)3944",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(RoleData)245_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "3711b38f96d53ef973f2d9a17c6aa1735fdd60c4d8a7bb649c24bd74d7b0f29f": {
+      "address": "0xbB17D2aB58708BD058A1DAb655a2e41a2C81fa17",
+      "txHash": "0xb2290d1cd11b61b85bc440f7455eecc25cf849e5a2e9cfafdacfbda90211b85b",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_bridge",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_address",
+            "contract": "BridgeGuardStorage",
+            "src": "contracts\\BridgeGuardStorage.sol:13"
+          },
+          {
+            "label": "_accommodationGuards",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_struct(Guard)4569_storage))",
+            "contract": "BridgeGuardStorage",
+            "src": "contracts\\BridgeGuardStorage.sol:16"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_struct(Guard)4569_storage)": {
+            "label": "mapping(address => struct IBridgeGuardTypes.Guard)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_struct(Guard)4569_storage))": {
+            "label": "mapping(uint256 => mapping(address => struct IBridgeGuardTypes.Guard))",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Guard)4569_storage": {
+            "label": "struct IBridgeGuardTypes.Guard",
+            "members": [
+              {
+                "label": "timeFrame",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "volumeLimit",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "lastResetTime",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "currentVolume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "4f7caf4e0db381195fdd480111c54ffd6d930e633d8443144d2b79104ff757e5": {
+      "address": "0xaBA178e2d1912618B707Bc221Aa419A57dF85a0B",
+      "txHash": "0x7ea52affdeb4a39c983316de4d30a916c6ebde12354fccc99451c83ecce611ed",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)245_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_pendingRelocationCounters",
+            "offset": 0,
+            "slot": "501",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:14"
+          },
+          {
+            "label": "_lastProcessedRelocationNonces",
+            "offset": 0,
+            "slot": "502",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:17"
+          },
+          {
+            "label": "_relocationModes",
+            "offset": 0,
+            "slot": "503",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_enum(OperationMode)4633))",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:20"
+          },
+          {
+            "label": "_relocations",
+            "offset": 0,
+            "slot": "504",
+            "type": "t_mapping(t_uint256,t_mapping(t_uint256,t_struct(Relocation)4650_storage))",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:23"
+          },
+          {
+            "label": "_accommodationModes",
+            "offset": 0,
+            "slot": "505",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_enum(OperationMode)4633))",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:26"
+          },
+          {
+            "label": "_lastAccommodationNonces",
+            "offset": 0,
+            "slot": "506",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:29"
+          },
+          {
+            "label": "_bridgeGuard",
+            "offset": 0,
+            "slot": "507",
+            "type": "t_address",
+            "contract": "MultiTokenBridgeStorageV2",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:38"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(OperationMode)4633": {
+            "label": "enum IMultiTokenBridgeTypes.OperationMode",
+            "members": [
+              "Unsupported",
+              "BurnOrMint",
+              "LockOrTransfer"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(RelocationStatus)4640": {
+            "label": "enum IMultiTokenBridgeTypes.RelocationStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Canceled",
+              "Processed",
+              "Revoked",
+              "Aborted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_enum(OperationMode)4633)": {
+            "label": "mapping(address => enum IMultiTokenBridgeTypes.OperationMode)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)245_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_enum(OperationMode)4633))": {
+            "label": "mapping(uint256 => mapping(address => enum IMultiTokenBridgeTypes.OperationMode))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_uint256,t_struct(Relocation)4650_storage))": {
+            "label": "mapping(uint256 => mapping(uint256 => struct IMultiTokenBridgeTypes.Relocation))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Relocation)4650_storage)": {
+            "label": "mapping(uint256 => struct IMultiTokenBridgeTypes.Relocation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Relocation)4650_storage": {
+            "label": "struct IMultiTokenBridgeTypes.Relocation",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(RelocationStatus)4640",
                 "offset": 0,
                 "slot": "3"
               }

--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -9,6 +9,11 @@
       "address": "0xB95eF5D556e0E8F12d8eeEA83BDDA1490b1996B3",
       "txHash": "0x56c0bdd8974706c951c0ce1ec138d91f4055a0b92106402bcf1e99da9b059d25",
       "kind": "transparent"
+    },
+    {
+      "address": "0xE832094C6E0f179143aBA4F3053A629243Ec8911",
+      "txHash": "0xa61fe249e52be81200b31ebee2b475db3c999b415134754aabc51591ffbf6ab5",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -1071,6 +1076,433 @@
               {
                 "label": "status",
                 "type": "t_enum(RelocationStatus)3934",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(RoleData)245_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "3711b38f96d53ef973f2d9a17c6aa1735fdd60c4d8a7bb649c24bd74d7b0f29f": {
+      "address": "0x241F08B96F534344c2A3a00952722c7a8f9aF082",
+      "txHash": "0xd659f0c17482a02db95ab93a77d6a2a159149f557b24154728ff18a95a258875",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_bridge",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_address",
+            "contract": "BridgeGuardStorage",
+            "src": "contracts\\BridgeGuardStorage.sol:13"
+          },
+          {
+            "label": "_accommodationGuards",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_struct(Guard)4569_storage))",
+            "contract": "BridgeGuardStorage",
+            "src": "contracts\\BridgeGuardStorage.sol:16"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_struct(Guard)4569_storage)": {
+            "label": "mapping(address => struct IBridgeGuardTypes.Guard)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_struct(Guard)4569_storage))": {
+            "label": "mapping(uint256 => mapping(address => struct IBridgeGuardTypes.Guard))",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Guard)4569_storage": {
+            "label": "struct IBridgeGuardTypes.Guard",
+            "members": [
+              {
+                "label": "timeFrame",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "volumeLimit",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "lastResetTime",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "currentVolume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "4f7caf4e0db381195fdd480111c54ffd6d930e633d8443144d2b79104ff757e5": {
+      "address": "0x25C78f8b47638AC2da0370667Bc717705E82De54",
+      "txHash": "0xc5da814bda3d1622ce7fb81903afd4252af987982a53fb7fb18dc74adf4247fe",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)245_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_pendingRelocationCounters",
+            "offset": 0,
+            "slot": "501",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:14"
+          },
+          {
+            "label": "_lastProcessedRelocationNonces",
+            "offset": 0,
+            "slot": "502",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:17"
+          },
+          {
+            "label": "_relocationModes",
+            "offset": 0,
+            "slot": "503",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_enum(OperationMode)4633))",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:20"
+          },
+          {
+            "label": "_relocations",
+            "offset": 0,
+            "slot": "504",
+            "type": "t_mapping(t_uint256,t_mapping(t_uint256,t_struct(Relocation)4650_storage))",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:23"
+          },
+          {
+            "label": "_accommodationModes",
+            "offset": 0,
+            "slot": "505",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_enum(OperationMode)4633))",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:26"
+          },
+          {
+            "label": "_lastAccommodationNonces",
+            "offset": 0,
+            "slot": "506",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:29"
+          },
+          {
+            "label": "_bridgeGuard",
+            "offset": 0,
+            "slot": "507",
+            "type": "t_address",
+            "contract": "MultiTokenBridgeStorageV2",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:38"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(OperationMode)4633": {
+            "label": "enum IMultiTokenBridgeTypes.OperationMode",
+            "members": [
+              "Unsupported",
+              "BurnOrMint",
+              "LockOrTransfer"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(RelocationStatus)4640": {
+            "label": "enum IMultiTokenBridgeTypes.RelocationStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Canceled",
+              "Processed",
+              "Revoked",
+              "Aborted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_enum(OperationMode)4633)": {
+            "label": "mapping(address => enum IMultiTokenBridgeTypes.OperationMode)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)245_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_enum(OperationMode)4633))": {
+            "label": "mapping(uint256 => mapping(address => enum IMultiTokenBridgeTypes.OperationMode))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_uint256,t_struct(Relocation)4650_storage))": {
+            "label": "mapping(uint256 => mapping(uint256 => struct IMultiTokenBridgeTypes.Relocation))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Relocation)4650_storage)": {
+            "label": "mapping(uint256 => struct IMultiTokenBridgeTypes.Relocation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Relocation)4650_storage": {
+            "label": "struct IMultiTokenBridgeTypes.Relocation",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(RelocationStatus)4640",
                 "offset": 0,
                 "slot": "3"
               }

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -9,6 +9,11 @@
       "address": "0x00cD046Ca9C42a3Cb5E450266012E78b93D2a131",
       "txHash": "0x848961ad226d28e12c794415250eee611dea2ba6205a319177687a3931ea4bfd",
       "kind": "transparent"
+    },
+    {
+      "address": "0x93E1B3E96AC7cf17F60244768200581b4344b80F",
+      "txHash": "0x70ef414081c3360bad71a101c7242198328ab85dc6f89cc2fd61f525caa31be6",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -1071,6 +1076,433 @@
               {
                 "label": "status",
                 "type": "t_enum(RelocationStatus)3934",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(RoleData)245_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "3711b38f96d53ef973f2d9a17c6aa1735fdd60c4d8a7bb649c24bd74d7b0f29f": {
+      "address": "0xAf8DcD97b7bc112ADE2E71327754d09BC76D6d6d",
+      "txHash": "0x24c1dbd45aaf5774b74129da9d2ca8230fb5618d4fffea90383d59e242e5684a",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_bridge",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_address",
+            "contract": "BridgeGuardStorage",
+            "src": "contracts\\BridgeGuardStorage.sol:13"
+          },
+          {
+            "label": "_accommodationGuards",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_struct(Guard)4569_storage))",
+            "contract": "BridgeGuardStorage",
+            "src": "contracts\\BridgeGuardStorage.sol:16"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_struct(Guard)4569_storage)": {
+            "label": "mapping(address => struct IBridgeGuardTypes.Guard)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_struct(Guard)4569_storage))": {
+            "label": "mapping(uint256 => mapping(address => struct IBridgeGuardTypes.Guard))",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Guard)4569_storage": {
+            "label": "struct IBridgeGuardTypes.Guard",
+            "members": [
+              {
+                "label": "timeFrame",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "volumeLimit",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "lastResetTime",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "currentVolume",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "4f7caf4e0db381195fdd480111c54ffd6d930e633d8443144d2b79104ff757e5": {
+      "address": "0x0Cc3ac34df5758e000B9E29f080b3De304Fe2913",
+      "txHash": "0x9d92a1d1e1ea98c95eb1749c537a83fa06094e90e061f517290f7b0d1a62fc09",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)245_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\PausableExtUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\access-control\\RescuableUpgradeable.sol:71"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "@cloudwalkinc\\brlc-contracts\\contracts\\storage\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_pendingRelocationCounters",
+            "offset": 0,
+            "slot": "501",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:14"
+          },
+          {
+            "label": "_lastProcessedRelocationNonces",
+            "offset": 0,
+            "slot": "502",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:17"
+          },
+          {
+            "label": "_relocationModes",
+            "offset": 0,
+            "slot": "503",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_enum(OperationMode)4633))",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:20"
+          },
+          {
+            "label": "_relocations",
+            "offset": 0,
+            "slot": "504",
+            "type": "t_mapping(t_uint256,t_mapping(t_uint256,t_struct(Relocation)4650_storage))",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:23"
+          },
+          {
+            "label": "_accommodationModes",
+            "offset": 0,
+            "slot": "505",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_enum(OperationMode)4633))",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:26"
+          },
+          {
+            "label": "_lastAccommodationNonces",
+            "offset": 0,
+            "slot": "506",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MultiTokenBridgeStorageV1",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:29"
+          },
+          {
+            "label": "_bridgeGuard",
+            "offset": 0,
+            "slot": "507",
+            "type": "t_address",
+            "contract": "MultiTokenBridgeStorageV2",
+            "src": "contracts\\MultiTokenBridgeStorage.sol:38"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(OperationMode)4633": {
+            "label": "enum IMultiTokenBridgeTypes.OperationMode",
+            "members": [
+              "Unsupported",
+              "BurnOrMint",
+              "LockOrTransfer"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(RelocationStatus)4640": {
+            "label": "enum IMultiTokenBridgeTypes.RelocationStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Canceled",
+              "Processed",
+              "Revoked",
+              "Aborted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_enum(OperationMode)4633)": {
+            "label": "mapping(address => enum IMultiTokenBridgeTypes.OperationMode)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)245_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_enum(OperationMode)4633))": {
+            "label": "mapping(uint256 => mapping(address => enum IMultiTokenBridgeTypes.OperationMode))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_uint256,t_struct(Relocation)4650_storage))": {
+            "label": "mapping(uint256 => mapping(uint256 => struct IMultiTokenBridgeTypes.Relocation))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Relocation)4650_storage)": {
+            "label": "mapping(uint256 => struct IMultiTokenBridgeTypes.Relocation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Relocation)4650_storage": {
+            "label": "struct IMultiTokenBridgeTypes.Relocation",
+            "members": [
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(RelocationStatus)4640",
                 "offset": 0,
                 "slot": "3"
               }

--- a/docs/deployed-contracts.json
+++ b/docs/deployed-contracts.json
@@ -5,9 +5,19 @@
     "address": "0x00cD046Ca9C42a3Cb5E450266012E78b93D2a131"
   },
   {
+    "name": "BridgeGuard",
+    "chainId": 2009,
+    "address": "0x93E1B3E96AC7cf17F60244768200581b4344b80F"
+  },
+  {
     "name": "MultiTokenBridge",
     "chainId": 2008,
     "address": "0xB95eF5D556e0E8F12d8eeEA83BDDA1490b1996B3"
+  },
+  {
+    "name": "BridgeGuard",
+    "chainId": 2008,
+    "address": "0xE832094C6E0f179143aBA4F3053A629243Ec8911"
   },
   {
     "name": "MultiTokenBridge",
@@ -15,8 +25,18 @@
     "address": "0x4e3512Cd8E36e94a23c3832271a2fF2B7357ddfc"
   },
   {
+    "name": "BridgeGuard",
+    "chainId": 1,
+    "address": "0x06A13288B0E2746D12D4f91EDCE1cAaCDc4409DC"
+  },
+  {
     "name": "MultiTokenBridge",
     "chainId": 5,
     "address": "0xa9a068A0E8Fb35C4c509FED72472df83FC9667D3"
+  },
+  {
+    "name": "BridgeGuard",
+    "chainId": 5,
+    "address": "0x68597B4F5c46f777B87EfBe91904EeA3c32D11FC"
   }
 ]

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -4,20 +4,26 @@
 | # | Name | Description | Address |
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0x7DAA8f8BE6f5C4d1e920aa708dD19269f9f03f7c](https://explorer.mainnet.cloudwalk.io/address/0x7DAA8f8BE6f5C4d1e920aa708dD19269f9f03f7c) |
-| 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x00cD046Ca9C42a3Cb5E450266012E78b93D2a131](https://explorer.mainnet.cloudwalk.io/address/0x00cD046Ca9C42a3Cb5E450266012E78b93D2a131) |
-| 3 | MultiTokenBridge | Proxy implementation | [0x1523029Ba1736B2Bc36dA4f2b81d33177f44a031](https://explorer.mainnet.cloudwalk.io/address/0x1523029Ba1736B2Bc36dA4f2b81d33177f44a031) |
+| 2 | MultiTokenBridge | Upgradeable proxy | [0x00cD046Ca9C42a3Cb5E450266012E78b93D2a131](https://explorer.mainnet.cloudwalk.io/address/0x00cD046Ca9C42a3Cb5E450266012E78b93D2a131) |
+| 3 || Proxy implementation | [0x0Cc3ac34df5758e000B9E29f080b3De304Fe2913](https://explorer.mainnet.cloudwalk.io/address/0x0Cc3ac34df5758e000B9E29f080b3De304Fe2913) |
+|||| <strike>[0x1523029Ba1736B2Bc36dA4f2b81d33177f44a031](https://explorer.mainnet.cloudwalk.io/address/0x1523029Ba1736B2Bc36dA4f2b81d33177f44a031)</strike> |
 |||| <strike>[0x84db1bb675DcEFc8512DE8d3e279b5f359f3Ac11](https://explorer.mainnet.cloudwalk.io/address/0x84db1bb675DcEFc8512DE8d3e279b5f359f3Ac11)</strike> |
 |||| <strike>[0xBb0ce84F243e173EC0a10b6046B39e1efD16C044](https://explorer.mainnet.cloudwalk.io/address/0xBb0ce84F243e173EC0a10b6046B39e1efD16C044)</strike> |
 |||| <strike>[0x517b3224aA87F9ACcA747fc596A0B68305508261](https://explorer.mainnet.cloudwalk.io/address/0x517b3224aA87F9ACcA747fc596A0B68305508261)</strike> |
+| 4 | BridgeGuard | Upgradeable proxy | [0x93E1B3E96AC7cf17F60244768200581b4344b80F](https://explorer.mainnet.cloudwalk.io/address/0x93E1B3E96AC7cf17F60244768200581b4344b80F) |
+| 5 || Proxy implementation | [0xAf8DcD97b7bc112ADE2E71327754d09BC76D6d6d](https://explorer.mainnet.cloudwalk.io/address/0xAf8DcD97b7bc112ADE2E71327754d09BC76D6d6d) |
 
 ### Ethereum (Mainnet)
 | # | Name | Description | Address |
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0x2eFAd672C5DD61C30c9A05cEf4D397657B35C48E](https://etherscan.io/address/0x2eFAd672C5DD61C30c9A05cEf4D397657B35C48E) |
-| 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x4e3512Cd8E36e94a23c3832271a2fF2B7357ddfc](https://etherscan.io/address/0x4e3512Cd8E36e94a23c3832271a2fF2B7357ddfc) |
-| 3 | MultiTokenBridge | Proxy implementation | [0x0bE91D3f2F71c1b0a98e92bdBFD8c96f5286A36F](https://etherscan.io/address/0x0bE91D3f2F71c1b0a98e92bdBFD8c96f5286A36F) |
+| 2 | MultiTokenBridge | Upgradeable proxy | [0x4e3512Cd8E36e94a23c3832271a2fF2B7357ddfc](https://etherscan.io/address/0x4e3512Cd8E36e94a23c3832271a2fF2B7357ddfc) |
+| 3 || Proxy implementation | [0xaBA178e2d1912618B707Bc221Aa419A57dF85a0B](https://etherscan.io/address/0xaBA178e2d1912618B707Bc221Aa419A57dF85a0B) |
+|||| <strike>[0x0bE91D3f2F71c1b0a98e92bdBFD8c96f5286A36F](https://etherscan.io/address/0x0bE91D3f2F71c1b0a98e92bdBFD8c96f5286A36F)</strike> |
 |||| <strike>[0xB5C2c7eC5558b0f667fB551709b57EfF35c24dB1](https://etherscan.io/address/0xB5C2c7eC5558b0f667fB551709b57EfF35c24dB1)</strike> |
 |||| <strike>[0xa1a228CCC4e28D42504fa919121e22e25deDc5B2](https://etherscan.io/address/0xa1a228CCC4e28D42504fa919121e22e25deDc5B2)</strike> |
+| 4 | BridgeGuard | Upgradeable proxy | [0x06A13288B0E2746D12D4f91EDCE1cAaCDc4409DC](https://etherscan.io/address/0x06A13288B0E2746D12D4f91EDCE1cAaCDc4409DC) |
+| 5 || Proxy implementation | [0xbB17D2aB58708BD058A1DAb655a2e41a2C81fa17](https://etherscan.io/address/0xbB17D2aB58708BD058A1DAb655a2e41a2C81fa17) |
 
 # BRLC Bridge on Testnet
 
@@ -25,17 +31,23 @@
 | # | Name | Description | Address |
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0x3398809dE9FBe780CF663D7F4FF7BB39E8be4DA3](https://explorer.testnet.cloudwalk.io/address/0x3398809dE9FBe780CF663D7F4FF7BB39E8be4DA3) |
-| 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xB95eF5D556e0E8F12d8eeEA83BDDA1490b1996B3](https://explorer.testnet.cloudwalk.io/address/0xB95eF5D556e0E8F12d8eeEA83BDDA1490b1996B3) |
-| 3 | MultiTokenBridge | Proxy implementation | [0xBc5A5e2FA69E32439E49F3d22772c415Cb2735CA](https://explorer.testnet.cloudwalk.io/address/0xBc5A5e2FA69E32439E49F3d22772c415Cb2735CA) |
+| 2 | MultiTokenBridge | Upgradeable proxy | [0xB95eF5D556e0E8F12d8eeEA83BDDA1490b1996B3](https://explorer.testnet.cloudwalk.io/address/0xB95eF5D556e0E8F12d8eeEA83BDDA1490b1996B3) |
+| 3 || Proxy implementation | [0x25C78f8b47638AC2da0370667Bc717705E82De54](https://explorer.testnet.cloudwalk.io/address/0x25C78f8b47638AC2da0370667Bc717705E82De54) |
+|||| <strike>[0xBc5A5e2FA69E32439E49F3d22772c415Cb2735CA](https://explorer.testnet.cloudwalk.io/address/0xBc5A5e2FA69E32439E49F3d22772c415Cb2735CA)</strike> |
 |||| <strike>[0xa17a66B2bdbb6bD5e39A43ed4B67Db6d4215733A](https://explorer.testnet.cloudwalk.io/address/0xa17a66B2bdbb6bD5e39A43ed4B67Db6d4215733A)</strike> |
 |||| <strike>[0x53807a10D75467de7aAE6cd1D1fa13e9dfF69A10](https://explorer.testnet.cloudwalk.io/address/0x53807a10D75467de7aAE6cd1D1fa13e9dfF69A10)</strike> |
 |||| <strike>[0xEb4b4c8F752982ddC1102D4AF2FC33826FbFb22a](https://explorer.testnet.cloudwalk.io/address/0xEb4b4c8F752982ddC1102D4AF2FC33826FbFb22a)</strike> |
+| 4 | BridgeGuard | Upgradeable proxy | [0xE832094C6E0f179143aBA4F3053A629243Ec8911](https://explorer.testnet.cloudwalk.io/address/0xE832094C6E0f179143aBA4F3053A629243Ec8911) |
+| 5 || Proxy implementation | [0x241F08B96F534344c2A3a00952722c7a8f9aF082](https://explorer.testnet.cloudwalk.io/address/0x241F08B96F534344c2A3a00952722c7a8f9aF082) |
 
 ### Görli (Testnet)
 | # | Name | Description | Address |
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0x8f029064a1A55d0eC8293cBDC1C1a2898B047EdA](https://goerli.etherscan.io/address/0x8f029064a1A55d0eC8293cBDC1C1a2898B047EdA) |
-| 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xa9a068A0E8Fb35C4c509FED72472df83FC9667D3](https://goerli.etherscan.io/address/0xa9a068A0E8Fb35C4c509FED72472df83FC9667D3) |
-| 3 | MultiTokenBridge | Proxy implementation | [0x60a6aE7f0A9FDf124C343f61121E30157E7793de](https://goerli.etherscan.io/address/0x60a6aE7f0A9FDf124C343f61121E30157E7793de) |
+| 2 | MultiTokenBridge | Upgradeable proxy | [0xa9a068A0E8Fb35C4c509FED72472df83FC9667D3](https://goerli.etherscan.io/address/0xa9a068A0E8Fb35C4c509FED72472df83FC9667D3) |
+| 3 || Proxy implementation | [0x70D93a27FfC58A48bAA9EABa6b7A3F6D42FB26e7](https://goerli.etherscan.io/address/0x70D93a27FfC58A48bAA9EABa6b7A3F6D42FB26e7) |
+|||| <strike>[0x60a6aE7f0A9FDf124C343f61121E30157E7793de](https://goerli.etherscan.io/address/0x60a6aE7f0A9FDf124C343f61121E30157E7793de)</strike> |
 |||| <strike>[0x80fE7f0E4958607430617050aba6C426A1286Fed](https://goerli.etherscan.io/address/0x80fE7f0E4958607430617050aba6C426A1286Fed)</strike> |
 |||| <strike>[0xbD87E49e91F930700B98b28744dC69B821d88b18](https://goerli.etherscan.io/address/0xbD87E49e91F930700B98b28744dC69B821d88b18)</strike> |
+| 4 | BridgeGuard | Upgradeable proxy | [0x68597B4F5c46f777B87EfBe91904EeA3c32D11FC](https://goerli.etherscan.io/address/0x68597B4F5c46f777B87EfBe91904EeA3c32D11FC) |
+| 5 || Proxy implementation | [0xD804d9F129fa3155aA76FbB1d468e673d3d5d8fF](https://goerli.etherscan.io/address/0xD804d9F129fa3155aA76FbB1d468e673d3d5d8fF) |


### PR DESCRIPTION
### Changes
- `BridgeGuard` contracts have been deployed across all the networks;
- `MultiTokenBridge` contracts have been upgraded across all the networks;
- `deployed-contracts` files have been updated after the smart contracts deploy and upgrade;
- `.openzeppelin` network files have been updated after the smart contracts deploy and upgrade.

#### Based on previous pull requests:
1. [Bridge guard feature](https://github.com/cloudwalk/brlc-bridge/pull/14)
2. [Bridge guard integration](https://github.com/cloudwalk/brlc-bridge/pull/15)